### PR TITLE
KUBEDR-5970: Skip PV patch step in Restore workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.2
+VERSION ?= v1.14.0.3
 
 TAG_LATEST ?= false
 

--- a/changelogs/unreleased/7953-shubham-pampattiwar
+++ b/changelogs/unreleased/7953-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Skip PV patch step in Restoe workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs


### PR DESCRIPTION
Skip PV patch step in Restore workflow for WaitForFirstConsumer VolumeBindingMode Pending state PVCs
Cherry-pick from upstream: https://github.com/vmware-tanzu/velero/pull/8006