### PR TITLE
KUBEDR-6409: Fix unattached PV crash and wrong config file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.10
+VERSION ?= v1.14.0.11
 
 TAG_LATEST ?= false
 

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -122,8 +122,8 @@ type veleroConfig struct {
 const (
 	CloudCasaNamespace = "cloudcasa-io"
 
-	// VeleroConfigMapName is the name of the configmap used to store configuration parameters
-	VeleroConfigMapName = "cloudcasa-io-velero-config"
+	// VeleroConfigMapPrefix is the name prefix of the configmap used to store configuration parameters
+	VeleroConfigMapPrefix = "cloudcasa-io-velero-config-"
 )
 
 func (i *itemKey) String() string {
@@ -341,7 +341,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 		resourcePolicy = backupRequest.ResPolicies
 	}
 
-	veleroConfig, err := GetVeleroConfig(log)
+	veleroConfig, err := GetVeleroConfig(log, backupRequest.Backup.Name)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get velero configuration")
 	}
@@ -927,19 +927,21 @@ func putVolumeInfos(
 }
 
 // GetVeleroConfig reads the configmap that contains Velero config parameters
-func GetVeleroConfig(log logrus.FieldLogger) (*veleroConfig, error) {
+func GetVeleroConfig(log logrus.FieldLogger, jobID string) (*veleroConfig, error) {
 	clientset, err := GetClientset(log)
 	if err != nil {
 		return nil, err
 	}
 
-	configMap, err := clientset.CoreV1().ConfigMaps(CloudCasaNamespace).Get(context.TODO(), VeleroConfigMapName, metav1.GetOptions{})
+	configmapName := VeleroConfigMapPrefix + jobID
+	configMap, err := clientset.CoreV1().ConfigMaps(CloudCasaNamespace).Get(context.TODO(), configmapName,
+		metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("Velero configuration configmap %q not found", VeleroConfigMapName)
+			log.Infof("Velero configuration configmap %q not found", configmapName)
 			return &veleroConfig{}, nil
 		}
-		log.Error(errors.Wrapf(err, "Failed to get %q configmap in %q namespace", VeleroConfigMapName, CloudCasaNamespace))
+		log.Error(errors.Wrapf(err, "Failed to get %q configmap in %q namespace", configmapName, CloudCasaNamespace))
 		return nil, err
 	}
 
@@ -947,7 +949,7 @@ func GetVeleroConfig(log logrus.FieldLogger) (*veleroConfig, error) {
 	if excludedPvcsJson, found := configMap.BinaryData["excludedPvcs"]; found {
 		if err := json.Unmarshal(excludedPvcsJson, &excludedPvcs); err != nil {
 			log.Error(errors.Wrapf(err, "Failed to parse excludedPvcs value %q from %q",
-				string(excludedPvcsJson), VeleroConfigMapName))
+				string(excludedPvcsJson), configmapName))
 			return nil, err
 		}
 	}

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -190,13 +190,19 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 		return false, itemFiles, nil
 	}
 
-	if ib.excludedPvcs != nil {
+	if ib.excludedPvcs != nil { // used only for the purpose of excluding unattached PVCs
 		switch groupResource {
 		case kuberesource.PersistentVolumes:
 			pv := new(corev1api.PersistentVolume)
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), pv); err != nil {
 				log.Errorf("Failed to convert unstructured PV %s to PersistentVolume structure: %v", metadata.GetName(), err)
 				return false, itemFiles, err
+			}
+
+			// PV that does not have a ClaimRef is not attached to a PVC so it can't be attached to a pod either
+			if pv.Spec.ClaimRef == nil {
+				log.Infof("Excluding PV %s because it is not bound to a PVC", metadata.GetName())
+				return false, itemFiles, nil
 			}
 
 			pvcPath := pv.Spec.ClaimRef.Namespace + "/" + pv.Spec.ClaimRef.Name


### PR DESCRIPTION
- Use the correct config file name
- Fix a crash when PV is not attached to a PVC
- We need to merge https://github.com/catalogicsoftware/cloudcasa-deployment/pull/286 after this is merged.