### PR TITLE
BugFix: Singe PVC restore fails to restore the PVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.19
+VERSION ?= v1.14.0.20
 
 TAG_LATEST ?= false
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -2759,6 +2759,11 @@ func handlePersistentVolumeClaims(
 	volumeInfo := findBackupVolumeInfo(ctx, namespace, name) // Retrieve backup volume info
 	if volumeInfo == nil {
 		log.Infof("No BackupVolumeInfo found for PVC '%s/%s', skipping CSI snapshot processing", namespace, name)
+
+		// Add the original PVC to filtered resources
+		log.Infof("Adding PersistentVolumeClaim '%s/%s' to filtered resources", namespace, name)
+		addItemToFilteredResources(resource, namespace, name, filteredResources, log)
+
 		return
 	}
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
- Add original PVC to list of restored resources even if CSI snapshots are not available.
- Bump up the Velero server image to v1.14.0.20

# Does your change fix a particular issue?

Fixes KUBEDR-6697

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
