### PR TITLE
KUBEDR-6731: Enable live backup of block PVCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.20
+VERSION ?= v1.14.0.21
 
 TAG_LATEST ?= false
 

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -670,13 +670,9 @@ func (p *pvcBackupItemAction) shouldSkipSnapshot(pvc *corev1api.PersistentVolume
 		}
 
 		if strings.HasPrefix(setBackupMethod, "LIVE") {
-			if *pvc.Spec.VolumeMode != corev1api.PersistentVolumeBlock {
-				p.log.Infof("Skipping snapshot of PVC %s/%s with storage class %s and backup method %s", pvc.Namespace, pvc.Name,
-					*pvc.Spec.StorageClassName, setBackupMethod)
-				return true, nil
-			} else {
-				p.log.Infof("Ignoring PVC %s/%s backup method %s because it is a block volume", pvc.Namespace, pvc.Name, setBackupMethod)
-			}
+			p.log.Infof("Skipping snapshot of PVC %s/%s with storage class %s and backup method %s", pvc.Namespace, pvc.Name,
+				*pvc.Spec.StorageClassName, setBackupMethod)
+			return true, nil
 		}
 	}
 


### PR DESCRIPTION
Enable live backup of block PVCs
Linked issue: https://github.com/catalogicsoftware/cloudcasa/pull/60350