### PR TITLE
Implement cancel in Velero backup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.22
+VERSION ?= v1.14.0.23
 
 TAG_LATEST ?= false
 

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -29,11 +29,13 @@ import (
 	"strings"
 	"time"
 
+	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeerrs "k8s.io/apimachinery/pkg/util/errors"
@@ -71,6 +73,8 @@ const BackupVersion = 1
 // BackupFormatVersion is the current backup version for Velero, including major, minor, and patch.
 const BackupFormatVersion = "1.1.0"
 
+var ErrBackupCancelled = errors.New("backup cancelled by user")
+
 // Backupper performs backups.
 type Backupper interface {
 	// Backup takes a backup using the specification in the velerov1api.Backup and writes backup and log data
@@ -98,6 +102,11 @@ type Backupper interface {
 		outBackupFile io.Writer,
 		backupItemActionResolver framework.BackupItemActionResolverV2,
 		asyncBIAOperations []*itemoperation.BackupOperation,
+	) error
+
+	CleanupBackup(
+		ctx context.Context,
+		req *Request,
 	) error
 }
 
@@ -358,6 +367,12 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 
 	log.WithField("progress", "").Infof("Collected %d items matching the backup spec from the Kubernetes API (actual number of items backed up may be more or less depending on velero.io/exclude-from-backup annotation, plugins returning additional related items to back up, etc.)", len(items))
 
+	// CANCEL CHECK HERE
+	if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled mid-execution, stopping")
+		return ErrBackupCancelled
+	}
+
 	updated := backupRequest.Backup.DeepCopy()
 	if updated.Status.Progress == nil {
 		updated.Status.Progress = &velerov1api.BackupProgress{}
@@ -454,6 +469,11 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 
 	backedUpGroupResources := map[schema.GroupResource]bool{}
 
+	if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled mid-execution, stopping")
+		return ErrBackupCancelled
+	}
+
 	for i, item := range items {
 		log.WithFields(map[string]interface{}{
 			"progress":  "",
@@ -461,6 +481,11 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 			"namespace": item.namespace,
 			"name":      item.name,
 		}).Infof("Processing item")
+
+		if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+			log.Warnf("Backup cancelled during item processing: %s/%s", item.namespace, item.name)
+			return ErrBackupCancelled
+		}
 
 		// use an anonymous func so we can defer-close/remove the file
 		// as soon as we're done with it
@@ -506,6 +531,10 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 	// no more progress updates will be sent on the 'update' channel
 	quit <- struct{}{}
 
+	if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled during item processing: %s/%s", backupRequest.Namespace, backupRequest.Name)
+		return ErrBackupCancelled
+	}
 	// back up CRD(this is a CRD definition of the resource, it's a CRD instance) for resource if found.
 	// We should only need to do this if we've backed up at least one item for the resource
 	// and the CRD type(this is the CRD type itself) is neither included or excluded.
@@ -735,6 +764,11 @@ func (kb *kubernetesBackupper) FinalizeBackup(
 			"name":      item.name,
 		}).Infof("Processing item")
 
+		if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+			log.Warnf("Backup cancelled before processing item: %s/%s", item.namespace, item.name)
+			errors.New("backup cancelled before final upload")
+		}
+
 		// use an anonymous func so we can defer-close/remove the file
 		// as soon as we're done with it
 		func() {
@@ -789,15 +823,29 @@ func (kb *kubernetesBackupper) FinalizeBackup(
 		return err
 	}
 
+	if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled before uploading backup volume info")
+		return errors.New("backup cancelled before uploading Volume Info")
+	}
+
 	if err := putVolumeInfos(backupRequest.Name, volumeInfos, backupStore); err != nil {
 		log.WithError(err).Errorf("fail to put the VolumeInfos for backup %s", backupRequest.Name)
 		return err
 	}
 
+	if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled before final tarball creation")
+		return errors.New("backup cancelled before upload")
+	}
+
 	// write new tar archive replacing files in original with content updateFiles for matches
-	if err := buildFinalTarball(tr, tw, updateFiles); err != nil {
+	if err := buildFinalTarball(tr, tw, updateFiles, backupRequest); err != nil {
 		log.Errorf("Error building final tarball: %s", err.Error())
 		return err
+	}
+	if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled after tarball build but before upload")
+		return errors.New("backup cancelled before final upload")
 	}
 
 	log.WithField("progress", "").Infof("Updated a total of %d items", len(backupRequest.BackedUpItems))
@@ -805,7 +853,72 @@ func (kb *kubernetesBackupper) FinalizeBackup(
 	return nil
 }
 
-func buildFinalTarball(tr *tar.Reader, tw *tar.Writer, updateFiles map[string]FileForArchive) error {
+func (kb *kubernetesBackupper) CleanupBackup(ctx context.Context, req *Request) error {
+	log := logrus.WithField("backup", req.Backup.Name)
+	log.Info("Starting cleanup of cancelled backup")
+
+	// FIRST: Clean up VolumeSnapshotContents
+	var vscList snapshotv1api.VolumeSnapshotContentList
+	if err := kb.kbClient.List(ctx, &vscList, &kbclient.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"velero.io/backup-name": req.Backup.Name,
+		}),
+	}); err != nil {
+		return errors.Wrap(err, "listing VolumeSnapshotContents")
+	}
+
+	for _, vsc := range vscList.Items {
+		if vsc.Status == nil || vsc.Status.ReadyToUse == nil {
+			continue
+		}
+		if !*vsc.Status.ReadyToUse && vsc.Status.Error == nil {
+			continue
+		}
+
+		// Update deletionPolicy if needed
+		if vsc.Spec.DeletionPolicy == snapshotv1api.VolumeSnapshotContentRetain {
+			vscCopy := vsc.DeepCopy()
+			vscCopy.Spec.DeletionPolicy = snapshotv1api.VolumeSnapshotContentDelete
+			if err := kb.kbClient.Update(ctx, vscCopy); err != nil {
+				log.WithError(err).Warnf("Failed to update deletionPolicy for VolumeSnapshotContent %s", vsc.Name)
+			}
+		}
+
+		log.Infof("Deleting VolumeSnapshotContent %s", vsc.Name)
+		if err := kb.kbClient.Delete(ctx, &vsc); err != nil && !apierrors.IsNotFound(err) {
+			log.WithError(err).Warnf("Failed to delete VolumeSnapshotContent %s", vsc.Name)
+		}
+	}
+
+	// THEN: Clean up VolumeSnapshots
+	var vsList snapshotv1api.VolumeSnapshotList
+	if err := kb.kbClient.List(ctx, &vsList, &kbclient.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"velero.io/backup-name": req.Backup.Name,
+		}),
+	}); err != nil {
+		return errors.Wrap(err, "listing VolumeSnapshots")
+	}
+
+	for _, vs := range vsList.Items {
+		if vs.Status == nil || vs.Status.ReadyToUse == nil {
+			continue // ongoing snapshot
+		}
+		if !*vs.Status.ReadyToUse && vs.Status.Error == nil {
+			continue // not done and no error
+		}
+
+		log.Infof("Deleting VolumeSnapshot %s/%s", vs.Namespace, vs.Name)
+		if err := kb.kbClient.Delete(ctx, &vs); err != nil && !apierrors.IsNotFound(err) {
+			log.WithError(err).Warnf("Failed to delete VolumeSnapshot %s/%s", vs.Namespace, vs.Name)
+		}
+	}
+
+	log.Info("Completed cleanup of cancelled backup")
+	return nil
+}
+
+func buildFinalTarball(tr *tar.Reader, tw *tar.Writer, updateFiles map[string]FileForArchive, backupRequest *Request) error {
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
@@ -814,6 +927,11 @@ func buildFinalTarball(tr *tar.Reader, tw *tar.Writer, updateFiles map[string]Fi
 		if err != nil {
 			return errors.WithStack(err)
 		}
+
+		if backupRequest.Context != nil && backupRequest.Context.Err() != nil {
+			return errors.New("backup cancelled: aborting tarball build")
+		}
+
 		newFile, ok := updateFiles[header.Name]
 		if ok {
 			// add updated file to archive, skip over tr file content

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -93,6 +93,11 @@ type FileForArchive struct {
 // In addition to the error return, backupItem also returns a bool indicating whether the item
 // was actually backed up.
 func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstructured, groupResource schema.GroupResource, preferredGVR schema.GroupVersionResource, mustInclude, finalize bool) (bool, []FileForArchive, error) {
+
+	if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+		return false, []FileForArchive{}, errors.New("backup cancelled during archive writing")
+	}
+
 	metadata, err := meta.Accessor(obj)
 	if err != nil {
 		return false, nil, err
@@ -120,6 +125,11 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 		return selectedForBackup, files, err
 	}
 	for _, file := range files {
+		if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+			//log.Warn("Backup cancelled while writing tar archive.")
+			return false, []FileForArchive{}, errors.New("backup cancelled during archive writing")
+		}
+
 		if err := ib.tarWriter.WriteHeader(file.Header); err != nil {
 			return false, []FileForArchive{}, errors.WithStack(err)
 		}
@@ -146,6 +156,11 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 		"resource":  groupResource.String(),
 		"namespace": namespace,
 	})
+
+	if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled, skipping item %s/%s", namespace, name)
+		return false, nil, errors.New("backup cancelled")
+	}
 
 	if mustInclude {
 		log.Infof("Skipping the exclusion checks for this resource")
@@ -240,6 +255,11 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 		pvbVolumes []string
 	)
 
+	if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+		log.Warnf("Cancelled before executing pre hooks for %s/%s", namespace, name)
+		backupErrs = append(backupErrs, err)
+		return false, itemFiles, kubeerrs.NewAggregate(backupErrs)
+	}
 	log.Debug("Executing pre hooks")
 	if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePre, ib.hookTracker); err != nil {
 		return false, itemFiles, err
@@ -291,9 +311,20 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 	// the group version of the object.
 	versionPath := resourceVersion(obj)
 
+	if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+		log.Warnf("Cancelled before executing plugin actions for %s/%s", namespace, name)
+		backupErrs = append(backupErrs, err)
+		return false, itemFiles, kubeerrs.NewAggregate(backupErrs)
+	}
+
 	updatedObj, additionalItemFiles, err := ib.executeActions(log, obj, groupResource, name, namespace, metadata, finalize)
 	if err != nil {
 		backupErrs = append(backupErrs, err)
+		if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+			log.Warnf("Cancelled before executing post hooks for %s/%s", namespace, name)
+			backupErrs = append(backupErrs, err)
+			return false, itemFiles, kubeerrs.NewAggregate(backupErrs)
+		}
 
 		// if there was an error running actions, execute post hooks and return
 		log.Debug("Executing post hooks")
@@ -317,6 +348,10 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 			backupErrs = append(backupErrs, err)
 		}
 
+		if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+			log.Warnf("Cancelled before executing PV snapshot for %s/%s", namespace, name)
+			return false, itemFiles, errors.New("backup cancelled")
+		}
 		if err := ib.takePVSnapshot(obj, log); err != nil {
 			backupErrs = append(backupErrs, err)
 		}
@@ -325,6 +360,12 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 	if groupResource == kuberesource.Pods && pod != nil {
 		// this function will return partial results, so process podVolumeBackups
 		// even if there are errors.
+		if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+			log.Warnf("Cancelled before executing Pod volume backup for %s/%s", namespace, name)
+			backupErrs = append(backupErrs, err)
+			return false, itemFiles, kubeerrs.NewAggregate(backupErrs)
+		}
+
 		podVolumeBackups, podVolumePVCBackupSummary, errs := ib.backupPodVolumes(log, pod, pvbVolumes)
 
 		backupErrs = append(backupErrs, errs...)
@@ -354,6 +395,11 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 		}
 	}
 
+	if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+		log.Warnf("Cancelled before executing post hooks for %s/%s", namespace, name)
+		backupErrs = append(backupErrs, err)
+		return false, itemFiles, kubeerrs.NewAggregate(backupErrs)
+	}
 	log.Debug("Executing post hooks")
 	if err := ib.itemHookHandler.HandleHooks(log, groupResource, obj, ib.backupRequest.ResourceHooks, hook.PhasePost, ib.hookTracker); err != nil {
 		backupErrs = append(backupErrs, err)
@@ -460,6 +506,10 @@ func (ib *itemBackupper) executeActions(
 			}
 		}
 
+		if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+			log.Warnf("Backup cancelled before executing custom action %s on %s/%s", actionName, namespace, name)
+			return nil, itemFiles, errors.New("backup cancelled")
+		}
 		updatedItem, additionalItemIdentifiers, operationID, postOperationItems, err := action.Execute(obj, ib.backupRequest.Backup)
 		if err != nil {
 			return nil, itemFiles, errors.Wrapf(err, "error executing custom action (groupResource=%s, namespace=%s, name=%s)", groupResource.String(), namespace, name)
@@ -516,6 +566,11 @@ func (ib *itemBackupper) executeActions(
 		}
 
 		for _, additionalItem := range additionalItemIdentifiers {
+			if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+				log.Warnf("Backup cancelled before processing additional item from action %s on %s/%s", actionName, namespace, name)
+				return nil, itemFiles, errors.New("backup cancelled")
+			}
+
 			gvr, resource, err := ib.discoveryHelper.ResourceFor(additionalItem.GroupResource.WithVersion(""))
 			if err != nil {
 				return nil, itemFiles, err
@@ -742,6 +797,11 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 	var errs []error
 	log.Info("Untrack the PV %s from the skipped volumes, because it's backed by Velero native snapshot.", pv.Name)
 	ib.backupRequest.SkippedPVTracker.Untrack(pv.Name)
+	if ib.backupRequest.Context != nil && ib.backupRequest.Context.Err() != nil {
+		log.Warnf("Backup cancelled before taking snapshot of volume for %s/%s", ib.backupRequest.Namespace, ib.backupRequest.Name)
+		return errors.New("backup cancelled")
+	}
+
 	snapshotID, err := volumeSnapshotter.CreateSnapshot(snapshot.Spec.ProviderVolumeID, snapshot.Spec.VolumeAZ, tags)
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "error taking snapshot of volume"))

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -197,6 +197,10 @@ func (r *itemCollector) getItemsFromResourceIdentifiers(
 func (r *itemCollector) getAllItems() []*kubernetesResource {
 	resources := r.getItems(nil)
 
+	if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+		r.log.Warnf("Backup cancelled before filtering namespaces: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+		return []*kubernetesResource{}
+	}
 	return r.nsTracker.filterNamespaces(resources)
 }
 
@@ -217,6 +221,10 @@ func (r *itemCollector) getItems(
 ) []*kubernetesResource {
 	var resources []*kubernetesResource
 	for _, group := range r.discoveryHelper.Resources() {
+		if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+			r.log.Warnf("Backup cancelled during resource listing: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+			return resources
+		}
 		groupItems, err := r.getGroupItems(r.log, group, resourceIDsMap)
 		if err != nil {
 			r.log.WithError(err).WithField("apiGroup", group.String()).
@@ -256,6 +264,10 @@ func (r *itemCollector) getGroupItems(
 
 	var items []*kubernetesResource
 	for _, resource := range group.APIResources {
+		if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+			r.log.Warnf("Backup cancelled while getting froup items: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+			return items, errors.New("backup cancelled by user")
+		}
 		resourceItems, err := r.getResourceItems(log, gv, resource, resourceIDsMap)
 		if err != nil {
 			log.WithError(err).WithField("resource", resource.String()).
@@ -372,6 +384,10 @@ func (r *itemCollector) getResourceItems(
 		}
 		var items []*kubernetesResource
 		for _, resourceID := range resourceIDs {
+			if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+				r.log.Warnf("Backup cancelled while getting resource items: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+				return items, errors.New("backup cancelled by user")
+			}
 			log.WithFields(
 				logrus.Fields{
 					"namespace": resourceID.Namespace,
@@ -456,6 +472,10 @@ func (r *itemCollector) getResourceItems(
 	var items []*kubernetesResource
 
 	for _, namespace := range namespacesToList {
+		if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+			r.log.Warnf("Backup cancelled while getting namespaces: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+			return items, errors.New("backup cancelled by user")
+		}
 		unstructuredItems, err := r.listResourceByLabelsPerNamespace(
 			namespace, gr, gv, resource, log)
 		if err != nil {
@@ -464,6 +484,10 @@ func (r *itemCollector) getResourceItems(
 
 		// Collect items in included Namespaces
 		for i := range unstructuredItems {
+			if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+				r.log.Warnf("Backup cancelled while getting unstructured items: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+				return items, errors.New("backup cancelled by user")
+			}
 			item := &unstructuredItems[i]
 
 			path, err := r.writeToFile(item)
@@ -525,6 +549,10 @@ func (r *itemCollector) listResourceByLabelsPerNamespace(
 	// Listing items for orLabelSelectors
 	errListingForNS := false
 	for _, label := range orLabelSelectors {
+		if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+			r.log.Warnf("Backup cancelled while getting namespaces: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+			return unstructuredItems, errors.New("backup cancelled by user")
+		}
 		unstructuredItems, err = r.listItemsForLabel(unstructuredItems, gr, label, resourceClient)
 		if err != nil {
 			errListingForNS = true
@@ -560,6 +588,10 @@ func (r *itemCollector) listResourceByLabelsPerNamespace(
 }
 
 func (r *itemCollector) writeToFile(item *unstructured.Unstructured) (string, error) {
+	if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+		r.log.Warnf("Backup cancelled during file write: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+		return "", errors.New("backup cancelled before writing file")
+	}
 	f, err := os.CreateTemp(r.dir, "")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating temp file")
@@ -669,6 +701,10 @@ func (r *itemCollector) processPagerClientCalls(
 	// TODO allow configuration of page buffer size
 	listPager.PageSize = int64(r.pageSize)
 	// Add each item to temporary slice
+	if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+		r.log.Warnf("Backup cancelled during resource listing: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+		return nil, errors.New("backup cancelled during listing labels")
+	}
 	list, paginated, err := listPager.List(context.Background(), metav1.ListOptions{LabelSelector: label})
 
 	if err != nil {
@@ -689,6 +725,10 @@ func (r *itemCollector) listItemsForLabel(
 	label string,
 	resourceClient client.Dynamic,
 ) ([]unstructured.Unstructured, error) {
+	if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+		r.log.Warnf("Backup cancelled during resource listing: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+		return unstructuredItems, errors.New("backup cancelled by user")
+	}
 	if r.pageSize > 0 {
 		// process pager client calls
 		list, err := r.processPagerClientCalls(gr, label, resourceClient)
@@ -697,6 +737,10 @@ func (r *itemCollector) listItemsForLabel(
 		}
 
 		err = meta.EachListItem(list, func(object runtime.Object) error {
+			if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+				r.log.Warnf("Backup cancelled while processing paginated list: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+				return errors.New("backup cancelled during pagination")
+			}
 			u, ok := object.(*unstructured.Unstructured)
 			if !ok {
 				r.log.WithError(errors.WithStack(fmt.Errorf("expected *unstructured.Unstructured but got %T", u))).
@@ -711,6 +755,10 @@ func (r *itemCollector) listItemsForLabel(
 			return unstructuredItems, err
 		}
 	} else {
+		if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+			r.log.Warnf("Backup cancelled during resource listing: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+			return unstructuredItems, errors.New("backup cancelled during listing labels")
+		}
 		unstructuredList, err := resourceClient.List(metav1.ListOptions{LabelSelector: label})
 		if err != nil {
 			r.log.WithError(errors.WithStack(err)).Error("Error listing items")
@@ -735,6 +783,10 @@ func (r *itemCollector) collectNamespaces(
 		return nil, errors.WithStack(err)
 	}
 
+	if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+		r.log.Warnf("Backup cancelled during resource listing: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+		return nil, errors.New("backup cancelled before collecting namespaces")
+	}
 	unstructuredList, err := resourceClient.List(metav1.ListOptions{})
 	if err != nil {
 		log.WithError(errors.WithStack(err)).Error("error list namespaces")
@@ -775,6 +827,10 @@ func (r *itemCollector) collectNamespaces(
 	var items []*kubernetesResource
 
 	for index := range unstructuredList.Items {
+		if r.backupRequest.Context != nil && r.backupRequest.Context.Err() != nil {
+			r.log.Warnf("Backup cancelled during resource listing: %s/%s", r.backupRequest.Namespace, r.backupRequest.Name)
+			return items, errors.New("backup cancelled by user")
+		}
 		path, err := r.writeToFile(&unstructuredList.Items[index])
 		if err != nil {
 			log.WithError(err).Errorf("Error writing item %s to file",

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backup
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -54,6 +55,7 @@ type Request struct {
 	SkippedPVTracker          *skipPVTracker
 	VolumesInformation        volume.BackupVolumesInformation
 	IncludeNamedResources     map[string]string
+	Context                   context.Context `json:"-"`
 }
 
 // BackupVolumesInformation contains the information needs by generating

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	snapshotv1api "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
@@ -30,9 +31,19 @@ import (
 	corev1api "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -219,27 +230,35 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	// Double-check we have the correct phase. In the unlikely event that multiple controller
-	// instances are running, it's possible for controller A to succeed in changing the phase to
-	// InProgress, while controller B's attempt to patch the phase fails. When controller B
-	// reprocesses the same backup, it will either show up as New (informer hasn't seen the update
-	// yet) or as InProgress. In the former case, the patch attempt will fail again, until the
-	// informer sees the update. In the latter case, after the informer has seen the update to
-	// InProgress, we still need this check so we can return nil to indicate we've finished processing
-	// this key (even though it was a no-op).
-	switch original.Status.Phase {
-	case "", velerov1api.BackupPhaseNew:
-		// only process new backups
-	default:
-		b.logger.WithFields(logrus.Fields{
-			"backup": kubeutil.NamespaceAndName(original),
-			"phase":  original.Status.Phase,
-		}).Debug("Backup is not handled")
+	if original.Annotations["velero.io/backup-cancelled"] == "true" {
+		log.Infof("Detected mid-backup cancellation for %s/%s. Cancelling context via tracker", req.Namespace, req.Name)
+		b.backupTracker.Cancel(req.Namespace, req.Name)
+		log.Infof("Backup marked as cancelled")
 		return ctrl.Result{}, nil
-	}
+	} else {
 
+		// Double-check we have the correct phase. In the unlikely event that multiple controller
+		// instances are running, it's possible for controller A to succeed in changing the phase to
+		// InProgress, while controller B's attempt to patch the phase fails. When controller B
+		// reprocesses the same backup, it will either show up as New (informer hasn't seen the update
+		// yet) or as InProgress. In the former case, the patch attempt will fail again, until the
+		// informer sees the update. In the latter case, after the informer has seen the update to
+		// InProgress, we still need this check so we can return nil to indicate we've finished processing
+		// this key (even though it was a no-op).
+		switch original.Status.Phase {
+		case "", velerov1api.BackupPhaseNew:
+			// only process new backups
+		default:
+			b.logger.WithFields(logrus.Fields{
+				"backup": kubeutil.NamespaceAndName(original),
+				"phase":  original.Status.Phase,
+			}).Debug("Backup is not handled")
+			return ctrl.Result{}, nil
+		}
+	}
 	log.Debug("Preparing backup request")
 	request := b.prepareBackupRequest(original, log)
+
 	if len(request.Status.ValidationErrors) > 0 {
 		request.Status.Phase = velerov1api.BackupPhaseFailedValidation
 	} else {
@@ -266,6 +285,7 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	original = request.Backup.DeepCopy()
 
 	b.backupTracker.Add(request.Namespace, request.Name)
+	request.Context = b.backupTracker.GetContext(request.Namespace, request.Name)
 	defer func() {
 		switch request.Status.Phase {
 		case velerov1api.BackupPhaseCompleted, velerov1api.BackupPhasePartiallyFailed, velerov1api.BackupPhaseFailed, velerov1api.BackupPhaseFailedValidation:
@@ -276,6 +296,8 @@ func (b *backupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	log.Debug("Running backup")
 
 	b.metrics.RegisterBackupAttempt(backupScheduleName)
+
+	go startBackupCancelWatcher(ctx, request.Namespace, request.Name, log, b)
 
 	// execution & upload of backup
 	if err := b.runBackup(request); err != nil {
@@ -817,53 +839,103 @@ func persistBackup(backup *pkgbackup.Request,
 	persistErrs := []error{}
 	backupJSON := new(bytes.Buffer)
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	if err := encode.To(backup.Backup, "json", backupJSON); err != nil {
 		persistErrs = append(persistErrs, errors.Wrap(err, "error encoding backup"))
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	// Velero-native volume snapshots (as opposed to CSI ones)
 	nativeVolumeSnapshots, errs := encode.ToJSONGzip(backup.VolumeSnapshots, "native volumesnapshots list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	var backupItemOperations *bytes.Buffer
 	backupItemOperations, errs = encode.ToJSONGzip(backup.GetItemOperationsList(), "backup item operations list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	podVolumeBackups, errs := encode.ToJSONGzip(backup.PodVolumeBackups, "pod volume backups list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	csiSnapshotJSON, errs := encode.ToJSONGzip(csiVolumeSnapshots, "csi volume snapshots list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	csiSnapshotContentsJSON, errs := encode.ToJSONGzip(csiVolumeSnapshotContents, "csi volume snapshot contents list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
+	}
+
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
 	}
 	csiSnapshotClassesJSON, errs := encode.ToJSONGzip(csiVolumeSnapshotClasses, "csi volume snapshot classes list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	backupResourceList, errs := encode.ToJSONGzip(backup.BackupResourceList(), "backup resources list")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	backupResult, errs := encode.ToJSONGzip(results, "backup results")
 	if errs != nil {
 		persistErrs = append(persistErrs, errs...)
 	}
 
 	backup.FillVolumesInformation()
-
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	volumeInfoJSON, errs := encode.ToJSONGzip(backup.VolumesInformation.Result(
 		csiVolumeSnapshots,
 		csiVolumeSnapshotContents,
@@ -904,6 +976,11 @@ func persistBackup(backup *pkgbackup.Request,
 		CSIVolumeSnapshotClasses:  csiSnapshotClassesJSON,
 		BackupVolumeInfo:          volumeInfoJSON,
 	}
+	if backup.Context != nil && backup.Context.Err() != nil {
+		logger.Warn("Backup cancelled before uploading to object store")
+		persistErrs = append(persistErrs, errors.New("backup cancelled before upload"))
+		return persistErrs
+	}
 	if err := backupStore.PutBackup(backupInfo); err != nil {
 		persistErrs = append(persistErrs, err)
 	}
@@ -934,4 +1011,117 @@ func oldAndNewFilterParametersUsedTogether(backupSpec velerov1api.BackupSpec) bo
 		(len(backupSpec.ExcludedNamespaceScopedResources) > 0)
 
 	return haveOldResourceFilterParameters && haveNewResourceFilterParameters
+}
+
+func startBackupCancelWatcher(ctx context.Context, namespace, name string, log logrus.FieldLogger, b *backupReconciler) error {
+
+	// 1. Create a dynamic client
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.WithError(err).Error("failed to build in-cluster config")
+		return err // fall back to original context
+	}
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.WithError(err).Error("failed to create dynamic client")
+		return err
+	}
+
+	// 2. Setup GVR for Velero Backup
+	gvr := schema.GroupVersionResource{
+		Group:    "cloudcasa.io",
+		Version:  "v1",
+		Resource: "backups",
+	}
+
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+
+	listWatch := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return dynClient.Resource(gvr).Namespace(namespace).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return dynClient.Resource(gvr).Namespace(namespace).Watch(context.TODO(), opts)
+		},
+	}
+
+	stopCh := make(chan struct{})
+	var once sync.Once
+	safeStop := func() {
+		once.Do(func() {
+			close(stopCh)
+		})
+	}
+
+	informer := cache.NewSharedInformer(
+		listWatch,
+		&unstructured.Unstructured{},
+		0, // No resync
+	)
+
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldBackup := oldObj.(*unstructured.Unstructured)
+			newBackup := newObj.(*unstructured.Unstructured)
+
+			oldAnnotations := oldBackup.GetAnnotations()
+			newAnnotations := newBackup.GetAnnotations()
+
+			_, oldHadCancel := oldAnnotations["velero.io/backup-cancelled"]
+			newCancelVal, newHasCancel := newAnnotations["velero.io/backup-cancelled"]
+
+			if !oldHadCancel && newHasCancel && newCancelVal == "true" {
+				log.Infof("Detected backup cancellation via shared informer: %s/%s", namespace, name)
+				b.backupTracker.Cancel(namespace, name)
+				safeStop()
+
+				// Use built-in retry to update the backup status
+				go func() {
+					ctx := context.Background()
+					key := types.NamespacedName{Namespace: namespace, Name: name}
+
+					updateErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+						var backup velerov1api.Backup
+						if err := b.kbClient.Get(ctx, key, &backup); err != nil {
+							log.WithError(err).Errorf("Failed to get Backup %s/%s for status update", namespace, name)
+							return err
+						}
+
+						// Only update if not already marked failed
+						if backup.Status.Phase != velerov1api.BackupPhaseFailed {
+							now := metav1.NewTime(time.Now())
+							backup.Status.Phase = velerov1api.BackupPhaseFailed
+							backup.Status.FailureReason = "Backup cancelled by user"
+							backup.Status.CompletionTimestamp = &now
+						}
+						return b.kbClient.Status().Update(ctx, &backup)
+					})
+
+					if updateErr != nil {
+						log.WithError(updateErr).Errorf("Failed to update status of Backup %s/%s", namespace, name)
+					} else {
+						log.Infof("Successfully updated Backup %s/%s status to Failed", namespace, name)
+					}
+				}()
+			}
+		},
+
+		DeleteFunc: func(obj interface{}) {
+			log.Infof("Backup CR %s/%s deleted. Stopping watcher", namespace, name)
+			b.backupTracker.Cancel(namespace, name)
+			safeStop()
+		},
+	})
+
+	go informer.Run(stopCh)
+
+	go func() {
+		<-ctx.Done()
+		log.Infof("Parent context for %s/%s was cancelled. Stopping watcher", namespace, name)
+		safeStop()
+	}()
+
+	return nil
 }

--- a/pkg/controller/backup_finalizer_controller.go
+++ b/pkg/controller/backup_finalizer_controller.go
@@ -100,6 +100,32 @@ func (r *backupFinalizerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
+	if val, ok := backup.Annotations["velero.io/backup-cancelled"]; ok && val == "true" {
+		log.Infof("Detected cancelled backup %s. Running cleanup tasks...", backup.Name)
+
+		original := backup.DeepCopy() // Save original before making changes
+
+		err := r.backupper.CleanupBackup(ctx, &pkgbackup.Request{
+			Backup: backup,
+		})
+		if err != nil {
+			log.Warnf("Failed to cleanup CSI snapshots for backup %s. Error is %s", backup.Name, err.Error())
+		}
+
+		if backup.Status.Phase != velerov1api.BackupPhaseFailed {
+			backup.Status.Phase = velerov1api.BackupPhaseFailed
+			backup.Status.FailureReason = "Backup was cancelled by the user"
+		}
+		backup.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now()}
+
+		// Patch the changes using the original
+		if err := r.client.Patch(ctx, backup, kbclient.MergeFrom(original)); err != nil {
+			log.WithError(err).Error("Failed to patch backup status after cancellation")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil // Don't fall through to finalization
+	}
+
 	switch backup.Status.Phase {
 	case velerov1api.BackupPhaseFinalizing, velerov1api.BackupPhaseFinalizingPartiallyFailed:
 		// only process backups finalizing after  plugin operations are complete

--- a/pkg/controller/backup_tracker.go
+++ b/pkg/controller/backup_tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -31,32 +32,44 @@ type BackupTracker interface {
 	Delete(ns, name string)
 	// Contains returns true if the tracker is tracking the backup.
 	Contains(ns, name string) bool
+	Cancel(ns, name string)
+	GetContext(ns, name string) context.Context
+}
+
+type backupContext struct {
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 type backupTracker struct {
-	lock    sync.RWMutex
-	backups sets.Set[string]
+	lock     sync.RWMutex
+	backups  sets.Set[string]
+	contexts map[string]*backupContext
 }
 
 // NewBackupTracker returns a new BackupTracker.
 func NewBackupTracker() BackupTracker {
 	return &backupTracker{
-		backups: sets.New[string](),
+		backups:  sets.New[string](),
+		contexts: make(map[string]*backupContext),
 	}
 }
 
 func (bt *backupTracker) Add(ns, name string) {
 	bt.lock.Lock()
 	defer bt.lock.Unlock()
+	key := backupTrackerKey(ns, name)
 
-	bt.backups.Insert(backupTrackerKey(ns, name))
-}
+	if bt.contexts == nil {
+		bt.contexts = make(map[string]*backupContext)
+	}
+	bt.backups.Insert(key)
 
-func (bt *backupTracker) Delete(ns, name string) {
-	bt.lock.Lock()
-	defer bt.lock.Unlock()
-
-	bt.backups.Delete(backupTrackerKey(ns, name))
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	bt.contexts[key] = &backupContext{
+		ctx:    ctx,
+		cancel: cancelFunc,
+	}
 }
 
 func (bt *backupTracker) Contains(ns, name string) bool {
@@ -66,6 +79,41 @@ func (bt *backupTracker) Contains(ns, name string) bool {
 	return bt.backups.Has(backupTrackerKey(ns, name))
 }
 
+func (bt *backupTracker) Delete(ns, name string) {
+	bt.lock.Lock()
+	defer bt.lock.Unlock()
+	key := backupTrackerKey(ns, name)
+
+	bt.backups.Delete(key)
+
+	// Safely cancel and delete from contexts map
+	if ctx, ok := bt.contexts[key]; ok && ctx.cancel != nil {
+		ctx.cancel()
+	}
+	delete(bt.contexts, key)
+}
+
+func (bt *backupTracker) Cancel(ns, name string) {
+	bt.lock.Lock()
+	defer bt.lock.Unlock()
+	key := backupTrackerKey(ns, name)
+
+	if ctx, ok := bt.contexts[key]; ok && ctx.cancel != nil {
+		ctx.cancel()
+	}
+}
+
 func backupTrackerKey(ns, name string) string {
 	return fmt.Sprintf("%s/%s", ns, name)
+}
+
+func (bt *backupTracker) GetContext(ns, name string) context.Context {
+	bt.lock.Lock()
+	defer bt.lock.Unlock()
+
+	key := backupTrackerKey(ns, name)
+	if ctx, ok := bt.contexts[key]; ok {
+		return ctx.ctx
+	}
+	return nil
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Implement cancel in Velero backup
- Updated Velero Image tag to v1.14.0.23
- Add centralized cancellation management for Backups
- Introduce ContextManager for centralized backup cancellation
- Refactor: inject ContextManager into backup controller constructor
- Enhance Reconcile() to:
  - Check for velero.io/backup-cancelled annotation before starting backup.
  - Start a goroutine to monitor the annotation during backup execution.
  - Cancel backup execution via context propagation when annotation is detected.
- Add cancellation check in itemBackupper to skip backing up items
- Add mid-execution cancellation checks in backup workflow
- Check for cancellation of backup before uploading the backup bundle
- Set the backup phase as FAILED in the backup finalizer

# Does your change fix a particular issue?
Fixes KubeDR-6606

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
