### PR TITLE
BugFix: KubeVirt VM restore status is incorrectly reported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.31
+VERSION ?= v1.14.0.32
 
 TAG_LATEST ?= false
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1427,17 +1427,31 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 
 		// After restore actions, check if it's a KubeVirt VM and track additional items
 		if kubevirtutil.IsKubeVirtVMResource(groupResource) {
+
+			ctx.log.Infof("Handling VM Restore. Name='%s'. SourceNamespace='%s'. TargetNamespace='%s'",
+				obj.GetName(),
+				obj.GetNamespace(),
+				namespace)
+
 			// Log the start of the VM restore
-			kubevirtutil.KubeVirtVMStartOp(ctx.log, obj.GetName(), obj.GetNamespace(), ctx.restore, ctx.kbClient)
+			kubevirtutil.KubeVirtVMStartOp(ctx.log, obj.GetName(), namespace, ctx.restore, ctx.kbClient)
 
 			// Save the VM's name and namespace for tracking additional items
 			vmName := obj.GetName()
-			vmNamespace := obj.GetNamespace()
+			vmNamespace := namespace
 
 			// Store additional items in the context's tracking map
 			for _, additionalItem := range executeOutput.AdditionalItems {
-				vmKey := kubevirtutil.ItemKey{Resource: groupResource.String(), Namespace: vmNamespace, Name: vmName}
-				additionalKey := kubevirtutil.ItemKey{Resource: additionalItem.GroupResource.String(), Namespace: additionalItem.Namespace, Name: additionalItem.Name}
+				vmKey := kubevirtutil.ItemKey{
+					Resource:  groupResource.String(),
+					Namespace: vmNamespace,
+					Name:      vmName,
+				}
+				additionalKey := kubevirtutil.ItemKey{
+					Resource:  additionalItem.GroupResource.String(),
+					Namespace: additionalItem.Namespace,
+					Name:      additionalItem.Name,
+				}
 				ctx.vmRelatedAdditionalItems[additionalKey] = vmKey
 			}
 		}
@@ -1883,7 +1897,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			ctx.log,
 			groupResource,
 			obj.GetName(),
-			obj.GetNamespace(),
+			namespace,
 			ctx.restore,
 			success,                    // Success status based on error presence
 			kubevirtutil.ToError(errs), // Convert errs to an error if applicable

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.928
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.31
+image = catalogicsoftware/velero:v1.14.0.32


### PR DESCRIPTION
- Pass originalNamespace instead of the mutated object's namespace so that the configmap update does not fail

Fixes KUBEDR-7414

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
