### PR TITLE
KUBEDR-7501: Handle stale PV <-> PVC reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.36
+VERSION ?= v1.14.0.37
 
 TAG_LATEST ?= false
 

--- a/pkg/restore/actions/csi/pvc_action.go
+++ b/pkg/restore/actions/csi/pvc_action.go
@@ -61,6 +61,7 @@ const (
 	HarvesterhCiIoOwnedBy                    = "harvesterhci.io/owned-by"
 	DefaultAzureFilesSleepDuration           = 10 * time.Second
 	CCAzureFilesPvcRestoreWaitTimeAnnotation = "cloudcasa-azure-files-pvc-restore-wait-sec"
+	pvcDeleteTimeoutSeconds                  = 2 * 60
 )
 
 const (
@@ -150,8 +151,12 @@ func (p *pvcRestoreItemAction) Execute(
 	})
 	logger.Info("Starting PVCRestoreItemAction for PVC")
 
+	if err := p.handleExistingPvc(input, &pvc); err != nil {
+		logger.Warnf("Failed to handle existing PVC: %v", err)
+	}
+
 	// If PVC already exists, returns early.
-	if p.isResourceExist(pvc, *input.Restore) {
+	if exists, _ := p.isResourceExist(pvc, *input.Restore); exists {
 		logger.Warnf("PVC already exists. Skip restore this PVC.")
 		return &velero.RestoreItemActionExecuteOutput{
 			UpdatedItem: input.Item,
@@ -311,6 +316,92 @@ func (p *pvcRestoreItemAction) Execute(
 		UpdatedItem: &unstructured.Unstructured{Object: pvcMap},
 		OperationID: operationID,
 	}, nil
+}
+
+// handleExistingPvc checks if target PVC exists and deletes it if the existing resource policy is "update"
+// and the PV has a "Retain" reclaim policy because PVC can't be updated and it will be in "Lost" state after restore.
+// If PVC is attached to a pod we can't delete it.
+func (p *pvcRestoreItemAction) handleExistingPvc(input *velero.RestoreItemActionExecuteInput, pvc *corev1api.PersistentVolumeClaim) error {
+
+	if input.Restore.Spec.ExistingResourcePolicy != velerov1api.PolicyTypeUpdate {
+		p.log.Info("Skipping check for existing PVC because existing resource policy is not \"update\"")
+		return nil
+	}
+
+	targetNamespace := pvc.Namespace
+	if newTargetNamespace, found := input.Restore.Spec.NamespaceMapping[pvc.Namespace]; found {
+		targetNamespace = newTargetNamespace
+	}
+
+	p.log.Infof("Checking if PVC %s/%s exists", targetNamespace, pvc.Name)
+
+	exists, existingPvc := p.isResourceExist(*pvc, *input.Restore)
+	if !exists {
+		p.log.Infof("PVC %s/%s not found", targetNamespace, pvc.Name)
+		return nil
+	}
+
+	if existingPvc.Spec.VolumeName == "" {
+		p.log.Infof("Existing PVC %s/%s has no associated PV", targetNamespace, pvc.Name)
+		return nil
+	}
+
+	clientset, _, err := csiutil.GetClients()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	existingPv, err := clientset.CoreV1().PersistentVolumes().Get(context.TODO(), existingPvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		p.log.Errorf("Failed to get existing PV %s: %v", existingPvc.Spec.VolumeName, err)
+		return err
+	}
+
+	if existingPv.Spec.PersistentVolumeReclaimPolicy != corev1api.PersistentVolumeReclaimRetain {
+		p.log.Infof("Existing PV %s does not have \"Retain\" reclaim policy", existingPv.Name)
+		return nil
+	}
+
+	podList, err := clientset.CoreV1().Pods(targetNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		p.log.Errorf("Failed to list pods in namespace %s: %s", targetNamespace, err)
+		return err
+	}
+
+	for _, pod := range podList.Items {
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvc.Name {
+				p.log.Infof("PVC %s/%s is attached to pod %s, can't delete it", targetNamespace, pvc.Name, pod.Name)
+				return nil
+			}
+		}
+	}
+
+	p.log.Infof("Deleting existing PVC %s/%s because existing resource policy is \"update\" and PV %s has \"Retain\" reclaim policy",
+		targetNamespace, pvc.Name, existingPv.Name)
+
+	if err := clientset.CoreV1().PersistentVolumeClaims(targetNamespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{}); err != nil {
+		p.log.Errorf("Failed to delete existing PVC %s/%s: %v", targetNamespace, pvc.Name, err)
+		return err
+	}
+
+	for try := range pvcDeleteTimeoutSeconds {
+		if exists, _ := p.isResourceExist(*pvc, *input.Restore); !exists {
+			p.log.Infof("PVC %s/%s deleted successfully", targetNamespace, pvc.Name)
+			return nil
+		}
+
+		if try%10 == 0 {
+			p.log.Infof("Waiting for PVC %s/%s to be deleted", targetNamespace, pvc.Name)
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	errorMessage := fmt.Sprintf("Failed to delete PVC %s/%s after %d seconds", targetNamespace, pvc.Name, pvcDeleteTimeoutSeconds)
+	p.log.Error(errorMessage)
+
+	return errors.New(errorMessage)
 }
 
 func (p *pvcRestoreItemAction) Name() string {
@@ -669,7 +760,7 @@ func restoreFromDataUploadResult(
 func (p *pvcRestoreItemAction) isResourceExist(
 	pvc corev1api.PersistentVolumeClaim,
 	restore velerov1api.Restore,
-) bool {
+) (bool, *corev1api.PersistentVolumeClaim) {
 	// get target namespace to restore into, if different from source namespace
 	targetNamespace := pvc.Namespace
 	if target, ok := restore.Spec.NamespaceMapping[pvc.Namespace]; ok {
@@ -685,9 +776,9 @@ func (p *pvcRestoreItemAction) isResourceExist(
 		},
 		tmpPVC,
 	); err == nil {
-		return true
+		return true, tmpPVC
 	}
-	return false
+	return false, nil
 }
 
 func NewPvcRestoreItemAction(f client.Factory) plugincommon.HandlerInitializer {

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -374,6 +374,7 @@ type restoreContext struct {
 	hooksWaitExecutor              *hooksWaitExecutor
 	vmRelatedAdditionalItems       map[kubevirtutil.ItemKey]kubevirtutil.ItemKey // Map to track VM's additional items
 	includeNamedResourcesSpecified bool
+	pvListCache                    *v1.PersistentVolumeList
 }
 
 type resourceClientKey struct {
@@ -1701,6 +1702,13 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		fromCluster, err = ctx.getResource(groupResource, obj, namespace, name)
 	}
 	if err != nil || fromCluster == nil {
+		if groupResource == kuberesource.PersistentVolumeClaims {
+			// PVC does not exist, clear PV binding to stale PVC with the same name
+			if err := ctx.patchStaleVolumeBinding(namespace, name); err != nil {
+				ctx.log.Warnf("Failed to clear stale PV binding for PVC %s/%s: %v", namespace, name, err)
+			}
+		}
+
 		// couldn't find the resource, attempt to create
 		ctx.log.Debugf("Creating %s: %v", obj.GroupVersionKind().Kind, name)
 		createdObj, restoreErr = resourceClient.Create(obj)
@@ -1957,6 +1965,89 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		)
 	}
 	return warnings, errs, itemExists
+}
+
+// patchStaleVolumeBinding checks if there is any PV that points to the given PVC and removes its binding info.
+// Function assumes that PVC does not yet exist and will be created, so if there is a PVC reference it is invalid.
+// If PV did not exist before the restore it will be created before this function is called but claimRef will not be set and
+// this function will exit with "No binding fields to remove for PV"
+func (ctx *restoreContext) patchStaleVolumeBinding(namespace string, pvcName string) error {
+
+	if ctx.restore.Spec.ExistingResourcePolicy != velerov1api.PolicyTypeUpdate {
+		ctx.log.Info("Skipping stale PV claimRef check because existing resource policy is not \"update\"")
+		return nil
+	}
+
+	ctx.log.Infof("Checking if there is any PV that is bound to PVC %s/%s with stale claimRef", namespace, pvcName)
+
+	if ctx.pvListCache == nil {
+		ctx.pvListCache = new(v1.PersistentVolumeList)
+		if err := ctx.kbClient.List(go_context.TODO(), ctx.pvListCache); err != nil {
+			ctx.log.Errorf("Failed to list PVs: %v", err)
+			ctx.pvListCache = nil
+			return err
+		}
+	}
+
+	var boundPvInCache *v1.PersistentVolume
+	for i := range ctx.pvListCache.Items {
+		pv := &ctx.pvListCache.Items[i]
+		if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Namespace == namespace && pv.Spec.ClaimRef.Name == pvcName {
+			boundPvInCache = pv // directly points to the cached entry so it can be updated
+			break
+		}
+	}
+
+	if boundPvInCache == nil {
+		ctx.log.Infof("No PV found with claimRef to PVC %s/%s", namespace, pvcName)
+		return nil
+	}
+
+	pvName := boundPvInCache.Name
+
+	pvObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(boundPvInCache)
+	if err != nil {
+		ctx.log.Errorf("Failed to convert PV %s to unstructured: %v", pvName, err)
+		return err
+	}
+	pv := &unstructured.Unstructured{Object: pvObject}
+
+	originalPv := pv.DeepCopy()
+	pv = resetVolumeBindingInfo(pv)
+
+	patchBytes, err := generatePatch(originalPv, pv)
+	if err != nil {
+		ctx.log.Errorf("Failed to generate patch to remove binding fields for PV %s: %v", pvName, err)
+		return err
+	}
+
+	if patchBytes == nil {
+		ctx.log.Infof("No binding fields to remove for PV %s", pvName)
+		return nil
+	}
+
+	pvClient, err := ctx.getResourceClient(kuberesource.PersistentVolumes, pv, "")
+	if err != nil {
+		ctx.log.Errorf("Failed to get PV resource client: %v", err)
+		return err
+	}
+
+	patchedPv, err := pvClient.Patch(pvName, patchBytes)
+	if err != nil {
+		ctx.log.Errorf("Failed to patch PV %s to remove binding fields: %v", pvName, err)
+		return err
+	}
+
+	// Update cache
+	var updatedPV v1.PersistentVolume
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(patchedPv.Object, &updatedPV); err == nil {
+		*boundPvInCache = updatedPV
+	} else {
+		ctx.log.Warnf("Failed to convert patched PV %s back to structured for cache update: %v", pvName, err)
+	}
+
+	ctx.log.Infof("Successfully removed binding fields for existing PV %s", pvName)
+	return nil
 }
 
 func isAlreadyExistsError(ctx *restoreContext, obj *unstructured.Unstructured, err error, client client.Dynamic) (bool, error) {

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.928
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.36
+image = catalogicsoftware/velero:v1.14.0.37


### PR DESCRIPTION
Handling 2 different cases where PVC to PV reference is broken
1. If overwrite is set and PV has "Retain" set, delete the PVC so it can be restored with correct PV reference.
2. If overwrite is set and if PV exists and is pointing to PVC being restored, clear its claimRef so it can be bound to the restored PVC.

Read new functions header comment for more details.

I tested:
- Restore without overwrite over existing PVC and PV.  PVC and PV was not updated as expected.
- Restore with overwrite where PVC and PV with "Retain" exists.  Namespace was restored correctly.
- Restore with overwrite where only PV exists that was previously bound to a PVC that was deleted. Namespace was restored correctly.