### PR TITLE
KUBEDR-7639: Set StartTimeout: 5 * time.Minute in plugin client config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.36-ocptest
+VERSION ?= v1.14.0.38-prod
 
 TAG_LATEST ?= false
 

--- a/pkg/plugin/clientmgmt/process/client_builder.go
+++ b/pkg/plugin/clientmgmt/process/client_builder.go
@@ -20,6 +20,8 @@ package process
 import (
 	"os"
 	"os/exec"
+	"strconv"
+	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
 	hcplugin "github.com/hashicorp/go-plugin"
@@ -65,6 +67,18 @@ func newLogrusAdapter(pluginLogger logrus.FieldLogger, logLevel logrus.Level) *l
 	return &logrusAdapter{impl: pluginLogger, level: logLevel}
 }
 
+func pluginStartTimeout() time.Duration {
+	timeoutMinutes := 5
+
+	if value, found := os.LookupEnv("PLUGIN_START_TIMEOUT"); found {
+		if parsed, err := strconv.Atoi(value); err == nil && parsed > 0 {
+			timeoutMinutes = parsed
+		}
+	}
+
+	return time.Duration(timeoutMinutes) * time.Minute
+}
+
 func (b *clientBuilder) clientConfig() *hcplugin.ClientConfig {
 	return &hcplugin.ClientConfig{
 		HandshakeConfig:  framework.Handshake(),
@@ -81,6 +95,7 @@ func (b *clientBuilder) clientConfig() *hcplugin.ClientConfig {
 		},
 		Logger: b.pluginLogger,
 		Cmd:    exec.Command(b.commandName, b.commandArgs...), //nolint:gosec // Internal call. No need to check the command line.
+		StartTimeout: pluginStartTimeout(),
 	}
 }
 

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.928
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.36-ocptest
+image = catalogicsoftware/velero:v1.14.0.38-prod


### PR DESCRIPTION
* Set StartTimeout: 5 * time.Minute in plugin client config

Fixes KUBEDR-7639

* KUBEDR-7639: PLUGIN_START_TIMEOUT env var

* bump velero tag

---------


(cherry picked from commit 626130e01e4ccc64e500f899a4078d97132dee8b)

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
