### PR TITLE
BugFix: DR restore doesn't respect selection from "drrecoveries"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.40-prod
+VERSION ?= v1.14.0.41-prod
 
 TAG_LATEST ?= false
 

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -470,6 +470,15 @@ func (ctx *restoreContext) execute() (results.Result, results.Result) {
 		errs.AddVeleroError(errors.Wrap(err, "error parsing backup contents"))
 		return warnings, errs
 	}
+	// --- diagnostic: dump the restore spec fields that control filtering. TODO: Change to "Debug" level log later ---
+	ctx.log.Infof("RestoreSpec: IncludedNamespaces=%v, ExcludedNamespaces=%v, IncludedResources=%v, ExcludedResources=%v, IncludeClusterResources=%v, IncludeNamedResources=%v",
+		ctx.restore.Spec.IncludedNamespaces,
+		ctx.restore.Spec.ExcludedNamespaces,
+		ctx.restore.Spec.IncludedResources,
+		ctx.restore.Spec.ExcludedResources,
+		ctx.restore.Spec.IncludeClusterResources,
+		ctx.restore.Spec.IncludeNamedResources,
+	)
 
 	/*
 		After the backup archive is parsed, this code now checks if the Restore spec includes IncludeNamedResources.
@@ -482,9 +491,37 @@ func (ctx *restoreContext) execute() (results.Result, results.Result) {
 		// Log that IncludeNamedResources is specified along with its value.
 		ctx.log.Infof("Restore spec includes IncludeNamedResources: %v", ctx.restore.Spec.IncludeNamedResources)
 
-		// enable cluster scoped resource restoration as the dependent resources may be cluster scoped.
-		enableClusterScopedResourcesInRestore := true
-		ctx.restore.Spec.IncludeClusterResources = &enableClusterScopedResourcesInRestore
+		// Only override IncludeClusterResources if the user did not explicitly
+		// set it in the Restore CR. When the user has set it (true or false),
+		// honour their intent.
+		if ctx.restore.Spec.IncludeClusterResources == nil {
+			// Scan the named resources to determine whether any are
+			// cluster-scoped. A name without a "/" separator means no
+			// namespace was specified, which indicates a cluster-scoped
+			// resource.
+			hasClusterScoped := false
+			for _, namesStr := range ctx.restore.Spec.IncludeNamedResources {
+				for _, n := range strings.Split(namesStr, ",") {
+					if !strings.Contains(strings.TrimSpace(n), "/") {
+						hasClusterScoped = true
+						break
+					}
+				}
+				if hasClusterScoped {
+					break
+				}
+			}
+
+			if hasClusterScoped {
+				enableClusterScopedResourcesInRestore := true
+				ctx.restore.Spec.IncludeClusterResources = &enableClusterScopedResourcesInRestore
+				ctx.log.Infof("IncludeClusterResources set to true because named resources include cluster-scoped items")
+			} else {
+				ctx.log.Infof("IncludeClusterResources left unset because all named resources are namespace-scoped; cluster-scoped dependencies will be restored via RestoreItemActions")
+			}
+		} else {
+			ctx.log.Infof("IncludeClusterResources already set to %v by user, not overriding", *ctx.restore.Spec.IncludeClusterResources)
+		}
 
 		// Filter the backupResources using our helper that logs detailed info.
 		backupResources = filterBackupResourcesByNamedResources(ctx, backupResources, ctx.restore.Spec.IncludeNamedResources)
@@ -792,6 +829,18 @@ func (ctx *restoreContext) processSelectedResource(
 					targetNS = n
 				} else {
 					targetNS = namespace
+				}
+
+				// Skip namespace objects that are not included in the restore's
+				// namespace filter. Without this check, all namespace objects
+				// present in the backup archive pass through the cluster-scoped
+				// resource exemption at getOrderedResourceCollection and reach
+				// this point, causing EnsureNamespaceExistsAndIsReady (below) to
+				// create every namespace from the backup on the target cluster,
+				// regardless of the restore spec's includedNamespaces.
+				if !ctx.namespaceIncludesExcludes.ShouldInclude(namespace) {
+					ctx.log.Infof("Skipping restore of namespace %s because it is not included in the restore's namespace filter", namespace)
+					continue
 				}
 			}
 			// If we don't know whether this namespace exists yet, attempt to create

--- a/plugins.ini
+++ b/plugins.ini
@@ -18,8 +18,8 @@ image = catalogicsoftware/kubevirt-velero-plugin:v0.7.1.1
 path = /plugins/kubevirt-velero-plugin
 
 [plugin:amds]
-image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.928
+image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.991
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.40-prod
+image = catalogicsoftware/velero:v1.14.0.41-prod


### PR DESCRIPTION
- Skip namespace objects that are not included in the restore's namespace filter.

Fixes KubeDR-7736

(cherry picked from commit e63a8bba653a46b0d2e813b65fcd9e0ed2601992)

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
