### PR TITLE
Check nil pointer in recordBackupMetrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.42-prod
+VERSION ?= v1.14.0.43-prod
 
 TAG_LATEST ?= false
 

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -797,7 +797,7 @@ func recordBackupMetrics(log logrus.FieldLogger, backup *velerov1api.Backup, bac
 		serverMetrics.SetBackupTarballSizeBytesGauge(backupScheduleName, backupSizeBytes)
 	}
 
-	if backup.Status.CompletionTimestamp != nil {
+	if backup.Status.CompletionTimestamp != nil && backup.Status.StartTimestamp != nil {
 		backupDuration := backup.Status.CompletionTimestamp.Time.Sub(backup.Status.StartTimestamp.Time)
 		backupDurationSeconds := float64(backupDuration / time.Second)
 		serverMetrics.RegisterBackupDuration(backupScheduleName, backupDurationSeconds)

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.991
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.42-prod
+image = catalogicsoftware/velero:v1.14.0.43-prod


### PR DESCRIPTION
- recordBackupMetrics dereferences StartTimestamp without nil check, causing panic when it is unset
- Add StartTimestamp != nil guard alongside existing CompletionTimestamp != nil check
- Affects backup-finalizer path when StartTimestamp is not set (e.g. CasaCreateBackupResourceForRestore)
- Skip duration metric when StartTimestamp is nil as the value would be meaningless
- Update Veelro Image tag from v1.14.0.42 to v1.14.0.43

Fixes KubeDR-7932

(cherry picked from commit 6151cdc96a050371ed6618211ada1f20c91447d8)

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
