### PR TITLE
Fix Prometheus counter panic in recordBackupMetrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.43-prod
+VERSION ?= v1.14.0.44-prod
 
 TAG_LATEST ?= false
 

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -806,7 +806,11 @@ func recordBackupMetrics(log logrus.FieldLogger, backup *velerov1api.Backup, bac
 	if !finalize {
 		serverMetrics.RegisterVolumeSnapshotAttempts(backupScheduleName, backup.Status.VolumeSnapshotsAttempted)
 		serverMetrics.RegisterVolumeSnapshotSuccesses(backupScheduleName, backup.Status.VolumeSnapshotsCompleted)
-		serverMetrics.RegisterVolumeSnapshotFailures(backupScheduleName, backup.Status.VolumeSnapshotsAttempted-backup.Status.VolumeSnapshotsCompleted)
+		nativeSnapshotFailures := backup.Status.VolumeSnapshotsAttempted - backup.Status.VolumeSnapshotsCompleted
+		if nativeSnapshotFailures < 0 {
+			nativeSnapshotFailures = 0
+		}
+		serverMetrics.RegisterVolumeSnapshotFailures(backupScheduleName, nativeSnapshotFailures)
 
 		if features.IsEnabled(velerov1api.CSIFeatureFlag) {
 			serverMetrics.RegisterCSISnapshotAttempts(backupScheduleName, backup.Name, backup.Status.CSIVolumeSnapshotsAttempted)
@@ -822,7 +826,11 @@ func recordBackupMetrics(log logrus.FieldLogger, backup *velerov1api.Backup, bac
 		}
 	} else if features.IsEnabled(velerov1api.CSIFeatureFlag) {
 		serverMetrics.RegisterCSISnapshotSuccesses(backupScheduleName, backup.Name, backup.Status.CSIVolumeSnapshotsCompleted)
-		serverMetrics.RegisterCSISnapshotFailures(backupScheduleName, backup.Name, backup.Status.CSIVolumeSnapshotsAttempted-backup.Status.CSIVolumeSnapshotsCompleted)
+		csiSnapshotFailures := backup.Status.CSIVolumeSnapshotsAttempted - backup.Status.CSIVolumeSnapshotsCompleted
+		if csiSnapshotFailures < 0 {
+			csiSnapshotFailures = 0
+		}
+		serverMetrics.RegisterCSISnapshotFailures(backupScheduleName, backup.Name, csiSnapshotFailures)
 	}
 }
 

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.991
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.43-prod
+image = catalogicsoftware/velero:v1.14.0.44-prod


### PR DESCRIPTION
- Clamp CSI snapshot failure count to zero before passing to RegisterCSISnapshotFailures to prevent negative value
- Clamp native snapshot failure count to zero before passing to RegisterVolumeSnapshotFailures for the same reason

Fixes KubeDR-7949

(cherry picked from e26f66dc10ecb03ecd91db7a3158af6690e09219)

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
