### PR TITLE
Fix race in DeleteVolumeSnapshot causing storage snapshot loss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.44
+VERSION ?= v1.14.0.45
 
 TAG_LATEST ?= false
 

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -717,15 +717,39 @@ func DeleteVolumeSnapshot(
 	client crclient.Client,
 	logger logrus.FieldLogger,
 ) {
-	modifyVSCFlag := false
-	if vs.Status != nil &&
+	vsReady := vs.Status != nil &&
 		vs.Status.BoundVolumeSnapshotContentName != nil &&
-		len(*vs.Status.BoundVolumeSnapshotContentName) > 0 &&
-		vsc.Spec.DeletionPolicy == snapshotv1api.VolumeSnapshotContentDelete {
-		modifyVSCFlag = true
+		len(*vs.Status.BoundVolumeSnapshotContentName) > 0
+
+	// Guard: if VS is not ready and DeletionPolicy is Delete, we must not
+	// proceed — deleting the VS would cascade-delete the storage snapshot.
+	if !vsReady {
+		if vsc.Spec.DeletionPolicy == snapshotv1api.VolumeSnapshotContentDelete {
+			vscInfo := ""
+			if vsc.Name != "" {
+				vscInfo = fmt.Sprintf(" and VolumeSnapshotContent %s (with DeletionPolicy=%s)", vsc.Name, vsc.Spec.DeletionPolicy)
+			}
+			logger.Warnf("VolumeSnapshot %s/%s is not ready; skipping deletion to prevent cascade-deleting the storage snapshot. "+
+				"The VolumeSnapshot%s will remain in the cluster "+
+				"until the retention period expires or the recovery point is explicitly deleted. "+
+				"Manual deletion of either resource before that will destroy the storage snapshot. "+
+				"To safely clean up manually, first patch the VolumeSnapshotContent DeletionPolicy to Retain, then delete the VolumeSnapshot.",
+				vs.Namespace, vs.Name, vscInfo)
+			return
+		}
+		logger.Infof("VolumeSnapshot %s/%s is not ready, but DeletionPolicy is %s. Proceeding with deletion.",
+			vs.Namespace, vs.Name, vsc.Spec.DeletionPolicy)
+	}
+
+	// Patch DeletionPolicy to Retain before deleting, so the storage snapshot survives.
+	modifyVSCFlag := vsReady && vsc.Spec.DeletionPolicy == snapshotv1api.VolumeSnapshotContentDelete
+
+	if modifyVSCFlag {
+		logger.Infof("VolumeSnapshotContent %s requires DeletionPolicy patch from Delete to Retain before deleting VolumeSnapshot %s/%s",
+			vsc.Name, vs.Namespace, vs.Name)
 	} else {
-		logger.Errorf("VolumeSnapshot %s/%s is not ready. This is not expected.",
-			vs.Namespace, vs.Name)
+		logger.Infof("No DeletionPolicy patch needed for VolumeSnapshot %s/%s (VSCReady=%v, VSC=%q, DeletionPolicy=%s)",
+			vs.Namespace, vs.Name, vsReady, vsc.Name, vsc.Spec.DeletionPolicy)
 	}
 
 	// Change VolumeSnapshotContent's DeletionPolicy to Retain before deleting VolumeSnapshot,
@@ -983,7 +1007,12 @@ func WaitUntilVSCHandleIsReady(
 			"timed out or failed watching VolumeSnapshot %s/%s for VSC binding",
 			volSnap.Namespace, volSnap.Name)
 	}
-
+	// Update the caller's VolumeSnapshot with the live version from the cluster
+	// so that Status (including BoundVolumeSnapshotContentName) is available to
+	// downstream callers such as DeleteVolumeSnapshot.
+	if latestVS != nil {
+		*volSnap = *latestVS
+	}
 	// -------------------------------------------------------------------------
 	// Interlude — Apply cc-pvc-name / cc-pvc-namespace annotations to the VSC.
 	//

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-rc.991
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.44
+image = catalogicsoftware/velero:v1.14.0.45


### PR DESCRIPTION
- WaitUntilVSCHandleIsReady now updates the caller's VS pointer with the live cluster version after Phase 1 binding completes
- DeleteVolumeSnapshot returns early only when VS is not ready AND DeletionPolicy is Delete, to prevent cascade deletion of the VSC and the underlying storage snapshot
- When VS is not ready but DeletionPolicy is Retain, deletion proceeds safely since Retain prevents cascade
- Orphaned VS from the early-return path will be cleaned up by the delete item action during backup deletion or when the retention period expires

Fixes KUBEDR-7981

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
