### PR TITLE
Fail fast for CSI drivers requiring a manual VolumeSnapshotClass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.48
+VERSION ?= v1.14.0.49
 
 TAG_LATEST ?= false
 

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -128,6 +128,14 @@ const (
 	VolumeSnapshotClassDriverPVCAnnotation                = "cloudcasa.io/csi-volumesnapshot-class"
 	VolumeSnapshotClassStorageClassBackupAnnotationPrefix = "cloudcasa.io/csi-sc-vsc-mapping-"
 
+	// SnapshotClassRequiredDriversAnnotation holds a comma-separated list of CSI
+	// driver names that require a manually-configured VolumeSnapshotClass. For a
+	// PVC whose driver is in this list, the plugin must NOT auto-create a
+	// VolumeSnapshotClass; if no user-configured VSC is available it fails that
+	// PVC's snapshot immediately with an actionable message. Set by the kubeagent
+	// on the Backup CR as runtime config.
+	SnapshotClassRequiredDriversAnnotation = "cloudcasa.io/snapshot-class-required-drivers"
+
 	// There is no release w/ these constants exported. Using the strings for now.
 	// CSI Annotation volumesnapshotclass
 	// https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/utils/util.go#L59-L60

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -197,7 +197,10 @@ func (p *pvcBackupItemAction) createVolumeSnapshot(
 			storageClass.Name,
 		)
 	}
-	p.log.Infof("VolumeSnapshotClass=%s", vsClass.Name)
+	p.log.Infof(
+		"Using VolumeSnapshotClass %s for PVC %s/%s (StorageClass %s, driver %s)",
+		vsClass.Name, pvc.Namespace, pvc.Name, storageClass.Name, storageClass.Provisioner,
+	)
 
 	vsLabels := map[string]string{}
 	for k, v := range pvc.ObjectMeta.Labels {

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -345,17 +345,88 @@ func GetVolumeSnapshotClass(
 		return snapshotClass, nil
 	}
 
-	// 4. Fallback to default behavior of fetching snapshot class based on label
+	// Drivers listed in the Backup's SnapshotClassRequiredDriversAnnotation must
+	// have a VolumeSnapshotClass configured explicitly (tiers 1-3 above, or a VSC
+	// the user labeled as the default in tier 4). For these drivers we do NOT
+	// allow the implicit selections that follow -- picking a lone unlabeled VSC
+	// (tier 4) or auto-creating one (tier 5) -- because the result would lack the
+	// driver-specific parameters the snapshot needs and would only time out.
+	isRequiredDriver := snapshotClassDriverRequired(backup, provisioner)
+
+	// 4. Fallback to default behavior of fetching snapshot class based on label.
+	// For required drivers the single-match fallback is disabled, so only a
+	// user-labeled VSC qualifies here.
 	snapshotClass, err = GetVolumeSnapshotClassForStorageClass(
-		provisioner, snapshotClasses)
+		provisioner, snapshotClasses, !isRequiredDriver)
 	if err == nil && snapshotClass != nil {
 		return snapshotClass, nil
 	}
 
+	// For a required driver, none of the explicit methods matched, so fail this
+	// PVC's snapshot immediately with an actionable message instead of falling
+	// through to the implicit auto-create.
+	if isRequiredDriver {
+		return nil, snapshotClassRequiredError(provisioner, pvc)
+	}
+
 	log.Debugf("No VolumeSnapshotClass found via standard methods: %v", err)
 
-	// 5. Absolute last resort fallback
+	// 5. Absolute last resort fallback.
 	return GetFallbackVolumeSnapshotClass(provisioner, log, crClient)
+}
+
+// snapshotClassRequiredError builds the actionable error returned when a CSI
+// driver requires a manually-configured VolumeSnapshotClass but none was found
+// through the explicit selection methods.
+func snapshotClassRequiredError(
+	provisioner string,
+	pvc *corev1api.PersistentVolumeClaim,
+) error {
+	pvcRef := "<unknown>"
+	storageClassName := "<unknown>"
+	if pvc != nil {
+		pvcRef = fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name)
+		if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
+			storageClassName = *pvc.Spec.StorageClassName
+		}
+	}
+	return errors.Errorf(
+		"no VolumeSnapshotClass configured for CSI driver %q (PVC %s, StorageClass %q). "+
+			"This driver requires custom parameters in its VolumeSnapshotClass, so CloudCasa "+
+			"will not create one automatically. Configure a VolumeSnapshotClass "+
+			"as described in the documentation, then retry the backup.",
+		provisioner, pvcRef, storageClassName,
+	)
+}
+
+// GetSnapshotClassRequiredDrivers parses the comma-separated list of CSI driver
+// names from the Backup's SnapshotClassRequiredDriversAnnotation. These drivers
+// require a manually-configured VolumeSnapshotClass, so the plugin must not
+// auto-create one for them. Returns an empty set when the annotation is absent
+// or empty, in which case the feature is a no-op.
+//
+// Names are lower-cased so membership checks are case-insensitive against a
+// StorageClass provisioner / VolumeSnapshotClass driver; callers must lower-case
+// the value they test with Has (see snapshotClassDriverRequired).
+func GetSnapshotClassRequiredDrivers(backup *velerov1api.Backup) sets.String {
+	drivers := sets.NewString()
+	if backup == nil {
+		return drivers
+	}
+	raw := backup.Annotations[velerov1api.SnapshotClassRequiredDriversAnnotation]
+	for _, d := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(d); trimmed != "" {
+			drivers.Insert(strings.ToLower(trimmed))
+		}
+	}
+	return drivers
+}
+
+// snapshotClassDriverRequired reports whether the given CSI driver/provisioner
+// is in the Backup's required-drivers list, matching case-insensitively to stay
+// consistent with the driver comparisons used by the other selection tiers.
+func snapshotClassDriverRequired(backup *velerov1api.Backup, provisioner string) bool {
+	return GetSnapshotClassRequiredDrivers(backup).Has(strings.ToLower(provisioner))
 }
 
 // Checks for StorageClass -> VolumeSnapshotClass mapping
@@ -483,9 +554,16 @@ func GetVolumeSnapshotClassFromBackupAnnotationsForDriver(
 
 // GetVolumeSnapshotClassForStorageClass returns a VolumeSnapshotClass
 // for the supplied volume provisioner/ driver name.
+//
+// A VSC carrying the selector label is always preferred. When
+// allowSingleMatchFallback is true and no labeled VSC exists, a lone VSC for the
+// driver is returned as an implicit default. Callers pass false to disable that
+// implicit fallback (e.g. drivers that require an explicitly-configured VSC), in
+// which case only a labeled VSC qualifies.
 func GetVolumeSnapshotClassForStorageClass(
 	provisioner string,
 	snapshotClasses *snapshotv1api.VolumeSnapshotClassList,
+	allowSingleMatchFallback bool,
 ) (*snapshotv1api.VolumeSnapshotClass, error) {
 	n := 0
 	var vsClass snapshotv1api.VolumeSnapshotClass
@@ -503,18 +581,24 @@ func GetVolumeSnapshotClassForStorageClass(
 			}
 		}
 	}
-	// If there's only one volumesnapshotclass for the driver, return it.
-	if n == 1 {
+	// If there's only one volumesnapshotclass for the driver, return it,
+	// unless the caller disabled this implicit fallback.
+	if allowSingleMatchFallback && n == 1 {
 		return &vsClass, nil
 	}
 	return nil, fmt.Errorf(
-		`failed to get VolumeSnapshotClass for provisioner %s, 
-		ensure that the desired VolumeSnapshot class has the %s label`,
-		provisioner, velerov1api.VolumeSnapshotClassSelectorLabel)
+		"failed to get VolumeSnapshotClass for provisioner %s, "+
+			"ensure that the desired VolumeSnapshot class is configured in Cloudcasa.",
+		provisioner)
 }
 
 // GetFallbackVolumeSnapshotClass attempts to find a usable class or creates a new one
 // if strict matching failed.
+//
+// Drivers that require a manually-configured VolumeSnapshotClass never reach this
+// function: GetVolumeSnapshotClass fails them fast at the explicit-methods
+// boundary (see snapshotClassRequiredError), so this fallback only runs for
+// drivers where auto-selection/creation is acceptable.
 func GetFallbackVolumeSnapshotClass(
 	provisioner string,
 	log logrus.FieldLogger,

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -875,7 +875,16 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		Driver: "bar.csi.k8s.io",
 	}
 
-	objs := []runtime.Object{hostpathClass, fooClass, barClass, fooClassWithoutLabel, barClass2}
+	// A single, unlabeled VSC for a driver. Selected implicitly via the
+	// single-match fallback only when that fallback is allowed.
+	hpeClassUnlabeled := &snapshotv1api.VolumeSnapshotClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hpe-snapclass",
+		},
+		Driver: "csi.hpe.com",
+	}
+
+	objs := []runtime.Object{hostpathClass, fooClass, barClass, fooClassWithoutLabel, barClass2, hpeClassUnlabeled}
 	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, objs...)
 
 	testCases := []struct {
@@ -950,6 +959,44 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 			expectedVSC: fooClass,
 			expectError: false,
 		},
+		{
+			name:       "required driver with no VSC at all fails fast instead of auto-creating",
+			driverName: "nutanix.csi.k8s.io",
+			pvc:        pvcNone,
+			backup: &velerov1api.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "requires-manual-vsc",
+					Annotations: map[string]string{
+						velerov1api.SnapshotClassRequiredDriversAnnotation: "csi.hpe.com, nutanix.csi.k8s.io",
+					},
+				},
+			},
+			expectedVSC: nil,
+			expectError: true,
+		},
+		{
+			name:       "required driver with a single UNLABELED VSC fails fast (implicit match disabled)",
+			driverName: "csi.hpe.com",
+			pvc:        pvcNone,
+			backup: &velerov1api.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "requires-manual-vsc",
+					Annotations: map[string]string{
+						velerov1api.SnapshotClassRequiredDriversAnnotation: "csi.hpe.com",
+					},
+				},
+			},
+			expectedVSC: nil,
+			expectError: true,
+		},
+		{
+			name:        "non-required driver with a single UNLABELED VSC is auto-selected via single-match",
+			driverName:  "csi.hpe.com",
+			pvc:         pvcNone,
+			backup:      backupNone,
+			expectedVSC: hpeClassUnlabeled,
+			expectError: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -963,6 +1010,85 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 			assert.Equal(t, tc.expectedVSC, actualSnapshotClass)
 		})
 	}
+}
+
+func TestGetSnapshotClassRequiredDrivers(t *testing.T) {
+	testCases := []struct {
+		name     string
+		backup   *velerov1api.Backup
+		expected []string
+	}{
+		{
+			name:     "nil backup returns empty set",
+			backup:   nil,
+			expected: []string{},
+		},
+		{
+			name:     "annotation absent returns empty set",
+			backup:   &velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+			expected: []string{},
+		},
+		{
+			name: "empty annotation returns empty set",
+			backup: &velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				velerov1api.SnapshotClassRequiredDriversAnnotation: "",
+			}}},
+			expected: []string{},
+		},
+		{
+			name: "comma-separated values are split and trimmed",
+			backup: &velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				velerov1api.SnapshotClassRequiredDriversAnnotation: " csi.hpe.com , nutanix.csi.hpe.com,cephfs.csi.ceph.com , ",
+			}}},
+			expected: []string{"cephfs.csi.ceph.com", "csi.hpe.com", "nutanix.csi.hpe.com"},
+		},
+		{
+			name: "values are lower-cased for case-insensitive matching",
+			backup: &velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				velerov1api.SnapshotClassRequiredDriversAnnotation: "CSI.HPE.COM,Nutanix.CSI.HPE.com",
+			}}},
+			expected: []string{"csi.hpe.com", "nutanix.csi.hpe.com"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetSnapshotClassRequiredDrivers(tc.backup)
+			assert.Equal(t, tc.expected, got.List())
+		})
+	}
+}
+
+func TestSnapshotClassDriverRequired(t *testing.T) {
+	backup := &velerov1api.Backup{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		velerov1api.SnapshotClassRequiredDriversAnnotation: "csi.hpe.com,cephfs.csi.ceph.com",
+	}}}
+
+	assert.True(t, snapshotClassDriverRequired(backup, "csi.hpe.com"))
+	// provisioner casing differs from the annotation but should still match.
+	assert.True(t, snapshotClassDriverRequired(backup, "CSI.HPE.COM"))
+	assert.False(t, snapshotClassDriverRequired(backup, "hostpath.csi.k8s.io"))
+	assert.False(t, snapshotClassDriverRequired(nil, "csi.hpe.com"))
+}
+
+func TestSnapshotClassRequiredError(t *testing.T) {
+	scName := "hpe-standard"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "data"},
+		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scName},
+	}
+
+	err := snapshotClassRequiredError("csi.hpe.com", pvc)
+	require.Error(t, err)
+	msg := err.Error()
+	// The message must name the driver, PVC, and StorageClass to stay actionable.
+	assert.Contains(t, msg, `"csi.hpe.com"`)
+	assert.Contains(t, msg, "ns1/data")
+	assert.Contains(t, msg, `"hpe-standard"`)
+
+	// Defensive path: nil PVC renders explicit placeholders, not empty fields.
+	errNil := snapshotClassRequiredError("csi.hpe.com", nil)
+	require.Error(t, errNil)
+	assert.Contains(t, errNil.Error(), "<unknown>")
 }
 
 func TestGetVolumeSnapshotClassForStorageClass(t *testing.T) {
@@ -1068,7 +1194,7 @@ func TestGetVolumeSnapshotClassForStorageClass(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualVSC, actualError := GetVolumeSnapshotClassForStorageClass(tc.driverName, snapshotClasses)
+			actualVSC, actualError := GetVolumeSnapshotClassForStorageClass(tc.driverName, snapshotClasses, true)
 
 			if tc.expectError {
 				assert.NotNil(t, actualError)

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-master.153
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.48
+image = catalogicsoftware/velero:v1.14.0.49


### PR DESCRIPTION
- Read new Backup annotation cloudcasa.io/snapshot-class-required-drivers
- Parse it into a driver set via GetSnapshotClassRequiredDrivers
- Gate the tier-5 auto-create in GetFallbackVolumeSnapshotClass
- For a listed driver with no usable VSC, return an actionable error
- Error names the driver, PVC, and StorageClass so users can fix it
- Fail only the affected PVC's snapshot; rest of the backup proceeds
- Honor any existing user-configured VSC; only block fabricating one
- No-op when the annotation is absent or empty (backward compatible)
- Add unit tests for the parser and the fail-fast path
- Bump up Velero image tag version to v1.14.0.49

Fixes KubeDR-7799

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
