### PR TITLE
Fix CSI snapshot loss on finalize and per-restore storage-class config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0.49
+VERSION ?= v1.14.0.50
 
 TAG_LATEST ?= false
 

--- a/internal/delete/actions/csi/volumesnapshot_action.go
+++ b/internal/delete/actions/csi/volumesnapshot_action.go
@@ -70,7 +70,7 @@ func (p *volumeSnapshotDeleteItemAction) Execute(
 	// that were not created in the process of creating the Velero
 	// backup being deleted.
 	if !kubeutil.HasBackupLabel(&vs.ObjectMeta, input.Backup.Name) {
-		p.log.Info(
+		p.log.Infof(
 			"VolumeSnapshot %s/%s was not taken by backup %s, skipping deletion",
 			vs.Namespace, vs.Name, input.Backup.Name,
 		)

--- a/internal/delete/actions/csi/volumesnapshotcontent_action.go
+++ b/internal/delete/actions/csi/volumesnapshotcontent_action.go
@@ -67,7 +67,7 @@ func (p *volumeSnapshotContentDeleteItemAction) Execute(
 	// So skip deleting VolumeSnapshotContent not have the backup name
 	// in its labels.
 	if !kubeutil.HasBackupLabel(&snapCont.ObjectMeta, input.Backup.Name) {
-		p.log.Info(
+		p.log.Infof(
 			"VolumeSnapshotContent %s was not taken by backup %s, skipping deletion",
 			snapCont.Name,
 			input.Backup.Name,
@@ -88,9 +88,13 @@ func (p *volumeSnapshotContentDeleteItemAction) Execute(
 		// may not delete it correctly due to the snapshot represented by VolumeSnapshotContent
 		// already deleted on cloud provider.
 		if apierrors.IsNotFound(err) {
+			snapshotHandle := "<unknown>"
+			if snapCont.Status != nil && snapCont.Status.SnapshotHandle != nil {
+				snapshotHandle = *snapCont.Status.SnapshotHandle
+			}
 			p.log.Warnf(
 				"VolumeSnapshotContent %s of backup %s cannot be found. May leave orphan snapshot %s on cloud provider.",
-				snapCont.Name, input.Backup.Name, *snapCont.Status.SnapshotHandle)
+				snapCont.Name, input.Backup.Name, snapshotHandle)
 			return nil
 		}
 		return errors.Wrapf(err, fmt.Sprintf(

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -87,6 +87,40 @@ func (p *volumeSnapshotBackupItemAction) Execute(
 		return nil, nil, "", nil, errors.WithStack(err)
 	}
 
+	// Handle the Finalizing / FinalizingPartiallyFailed phase up front and return,
+	// BEFORE calling WaitUntilVSCHandleIsReady. In these phases the CSI snapshot was
+	// already captured successfully during the InProgress phase; the backup finalizer
+	// only replays this action to clean up the now-ephemeral VolumeSnapshot. The wait
+	// can fail for transient reasons at finalize time (e.g. the optional plugin
+	// ConfigMap has been removed), and its error path runs the destructive
+	// CleanupVolumeSnapshot, which flips the VSC DeletionPolicy to Delete and
+	// cascade-deletes the underlying storage snapshot — the very snapshot a concurrent
+	// restore (e.g. the COPY workflow's temporary PVC) may still be provisioning from.
+	// DeleteVolumeSnapshot removes the VolumeSnapshot while preserving the snapshot
+	// (it keeps, or forces, the VSC DeletionPolicy to Retain).
+	if backup.Status.Phase == velerov1api.BackupPhaseFinalizing ||
+		backup.Status.Phase == velerov1api.BackupPhaseFinalizingPartiallyFailed {
+		p.log.
+			WithField("Backup", fmt.Sprintf("%s/%s", backup.Namespace, backup.Name)).
+			WithField("BackupPhase", backup.Status.Phase).
+			Debugf("Cleaning up VolumeSnapshot during finalize")
+
+		vsc, err := csi.GetVolumeSnapshotContentForVolumeSnapshot(vs, p.snapshotClient)
+		if err != nil {
+			// Could not resolve the bound VolumeSnapshotContent. Deleting the
+			// VolumeSnapshot now could cascade-delete a Delete-policy VSC and its
+			// storage snapshot, so leave the VolumeSnapshot in place; it will be
+			// reclaimed by the delete item action when the backup is deleted.
+			p.log.Warnf(
+				"Skipping finalize cleanup of VolumeSnapshot %s/%s; could not get bound VolumeSnapshotContent: %v",
+				vs.Namespace, vs.Name, err)
+			return item, nil, "", nil, nil
+		}
+
+		csi.DeleteVolumeSnapshot(*vs, *vsc, backup, p.crClient, p.log)
+		return item, nil, "", nil, nil
+	}
+
 	volumeSnapshotClassName := ""
 	if vs.Spec.VolumeSnapshotClassName != nil {
 		volumeSnapshotClassName = *vs.Spec.VolumeSnapshotClassName
@@ -131,20 +165,6 @@ func (p *volumeSnapshotBackupItemAction) Execute(
 			vs.Namespace, vs.Name, err)
 		csi.CleanupVolumeSnapshot(vs, p.crClient, p.log)
 		return nil, nil, "", nil, errors.WithStack(err)
-	}
-
-	if backup.Status.Phase == velerov1api.BackupPhaseFinalizing ||
-		backup.Status.Phase == velerov1api.BackupPhaseFinalizingPartiallyFailed {
-		p.log.
-			WithField("Backup", fmt.Sprintf("%s/%s", backup.Namespace, backup.Name)).
-			WithField("BackupPhase", backup.Status.Phase).Debugf("Clean VolumeSnapshots.")
-
-		if vsc == nil {
-			vsc = &snapshotv1api.VolumeSnapshotContent{}
-		}
-
-		csi.DeleteVolumeSnapshot(*vs, *vsc, backup, p.crClient, p.log)
-		return item, nil, "", nil, nil
 	}
 
 	annotations := make(map[string]string)

--- a/pkg/restore/actions/change_storageclass_action.go
+++ b/pkg/restore/actions/change_storageclass_action.go
@@ -23,15 +23,21 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	storagev1client "k8s.io/client-go/kubernetes/typed/storage/v1"
 
-	"github.com/vmware-tanzu/velero/pkg/plugin/framework/common"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 )
+
+// changeStorageClassConfigMapPrefix is the name prefix of the per-restore
+// ConfigMap the kubeagent creates for storage-class remapping. The full name is
+// changeStorageClassConfigMapPrefix + <restore name>. One ConfigMap is created
+// per restore so that restores running in parallel each select their own mapping.
+const changeStorageClassConfigMapPrefix = "cloudcasa-io-change-sc-"
 
 // ChangeStorageClassAction updates a PV or PVC's storage class name
 // if a mapping is found in the plugin's config map.
@@ -68,13 +74,24 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 	a.logger.Info("Executing ChangeStorageClassAction")
 	defer a.logger.Info("Done executing ChangeStorageClassAction")
 
-	a.logger.Debug("Getting plugin config")
-	config, err := common.GetPluginConfig(common.PluginKindRestoreItemAction, "velero.io/change-storage-class", a.configMapClient)
+	// The kubeagent runs restores in parallel and creates one change-storage-class
+	// ConfigMap per restore, named "cloudcasa-io-change-sc-<restoreName>". Fetch this
+	// restore's ConfigMap by name instead of listing on the shared plugin-config
+	// label: with concurrent restores that list would either error ("found more than
+	// one ConfigMap ...") or pick another restore's mapping. A by-name Get is also
+	// immune to orphaned ConfigMaps left behind by crashed restores.
+	cmName := changeStorageClassConfigMapPrefix + input.Restore.GetName()
+	a.logger.Debugf("Getting change-storage-class ConfigMap %s", cmName)
+	config, err := a.configMapClient.Get(context.TODO(), cmName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		a.logger.Debugf("No change-storage-class ConfigMap %s; no storage class mappings", cmName)
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
-	if config == nil || len(config.Data) == 0 {
+	if len(config.Data) == 0 {
 		a.logger.Debug("No storage class mappings found")
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}

--- a/pkg/restore/actions/change_storageclass_action_test.go
+++ b/pkg/restore/actions/change_storageclass_action_test.go
@@ -225,7 +225,15 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			)
 
 			// set up test data
+			const restoreName = "restore-1"
 			if tc.configMap != nil {
+				// The kubeagent creates one change-storage-class ConfigMap per restore,
+				// named cloudcasa-io-change-sc-<restoreName>. Rename the test's change-sc
+				// ConfigMap to that per-restore name so the by-name lookup finds it; leave
+				// other-plugin ConfigMaps under their own name so the lookup misses them.
+				if tc.configMap.Labels["velero.io/change-storage-class"] == "RestoreItemAction" {
+					tc.configMap.Name = changeStorageClassConfigMapPrefix + restoreName
+				}
 				_, err := clientset.CoreV1().ConfigMaps(tc.configMap.Namespace).Create(context.TODO(), tc.configMap, metav1.CreateOptions{})
 				require.NoError(t, err)
 			}
@@ -249,6 +257,7 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 				Item: &unstructured.Unstructured{
 					Object: unstructuredMap,
 				},
+				Restore: builder.ForRestore("velero", restoreName).Result(),
 			}
 
 			// execute method under test
@@ -266,6 +275,92 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 
 				assert.Equal(t, &unstructured.Unstructured{Object: wantUnstructured}, res.UpdatedItem)
 			}
+		})
+	}
+}
+
+// TestChangeStorageClassActionExecutePerRestore verifies that the action selects the
+// ConfigMap belonging to the restore being processed (by name), so that restores
+// running in parallel — and ConfigMaps orphaned by other/crashed restores — never
+// cross-contaminate and never trigger a "more than one ConfigMap" error.
+func TestChangeStorageClassActionExecutePerRestore(t *testing.T) {
+	newCM := func(restoreName, oldSC, newSC string) *corev1api.ConfigMap {
+		return builder.ForConfigMap("velero", changeStorageClassConfigMapPrefix+restoreName).
+			ObjectMeta(builder.WithLabels(
+				"velero.io/plugin-config", "",
+				"velero.io/change-storage-class", "RestoreItemAction",
+				"cloudcasa.io/change-storage-class", "true",
+				"cloudcasa.io/job-id-for-change-storage-class", restoreName,
+			)).
+			Data(oldSC, newSC).
+			Result()
+	}
+
+	tests := []struct {
+		name           string
+		restoreName    string
+		configMaps     []*corev1api.ConfigMap
+		storageClasses []string
+		wantSC         string // expected storageClassName on the restored PVC
+	}{
+		{
+			name:        "selects this restore's mapping and ignores other restores'",
+			restoreName: "restore-1",
+			configMaps: []*corev1api.ConfigMap{
+				newCM("restore-1", "storageclass-1", "storageclass-a"),
+				newCM("restore-2", "storageclass-1", "storageclass-b"), // other restore, must be ignored
+			},
+			storageClasses: []string{"storageclass-a", "storageclass-b"},
+			wantSC:         "storageclass-a",
+		},
+		{
+			name:        "no ConfigMap for this restore is a no-op even when others exist",
+			restoreName: "restore-1",
+			configMaps: []*corev1api.ConfigMap{
+				newCM("restore-2", "storageclass-1", "storageclass-b"),
+				newCM("restore-3", "storageclass-1", "storageclass-c"),
+			},
+			wantSC: "storageclass-1", // unchanged
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			a := NewChangeStorageClassAction(
+				logrus.StandardLogger(),
+				clientset.CoreV1().ConfigMaps("velero"),
+				clientset.StorageV1().StorageClasses(),
+			)
+
+			for _, cm := range tc.configMaps {
+				_, err := clientset.CoreV1().ConfigMaps(cm.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+			for _, sc := range tc.storageClasses {
+				_, err := clientset.StorageV1().StorageClasses().Create(context.TODO(), builder.ForStorageClass(sc).Result(), metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			pvc := builder.ForPersistentVolumeClaim("app", "pvc-1").StorageClass("storageclass-1").Result()
+			unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pvc)
+			require.NoError(t, err)
+
+			input := &velero.RestoreItemActionExecuteInput{
+				Item:    &unstructured.Unstructured{Object: unstructuredMap},
+				Restore: builder.ForRestore("velero", tc.restoreName).Result(),
+			}
+
+			res, err := a.Execute(input)
+			require.NoError(t, err)
+
+			gotPVC := new(corev1api.PersistentVolumeClaim)
+			require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(res.UpdatedItem.UnstructuredContent(), gotPVC))
+			gotSC := ""
+			if gotPVC.Spec.StorageClassName != nil {
+				gotSC = *gotPVC.Spec.StorageClassName
+			}
+			assert.Equal(t, tc.wantSC, gotSC)
 		})
 	}
 }

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -1008,16 +1008,25 @@ func WaitUntilVSCHandleIsReady(
 		catalogic.DeleteSnapshotProgressConfigMap(jobID, log)
 	}()
 
-	// Allow the plugin config to override the timeout.
+	// The plugin ConfigMap only carries an OPTIONAL CSI-snapshot-timeout override.
+	// It is routinely absent by the time this runs (e.g. the kubeagent removes it
+	// once the backup job finishes, around the finalize phase). Treat a missing or
+	// unreadable ConfigMap as non-fatal and fall back to the timeout the caller
+	// passed in (backup.Spec.CSISnapshotTimeout). Returning an error here would send
+	// the caller (VolumeSnapshotBackupItemAction) down the destructive
+	// CleanupVolumeSnapshot path, which flips the VSC DeletionPolicy to Delete and
+	// cascade-deletes the underlying storage snapshot a restore may still need.
 	config, err := catalogic.GetPluginConfig(jobID, log)
 	if err != nil {
-		log.WithError(err).Error("Failed to get plugin config")
-		return nil, errors.Wrap(err, "error getting plugin config")
-	}
-	log.Infof("Plugin config: %+v", config)
-	if config.CsiSnapshotTimeout > 0 {
-		csiSnapshotTimeout = time.Duration(config.CsiSnapshotTimeout) * time.Minute
-		log.Infof("Using configured CSI snapshot Timeout=%v", csiSnapshotTimeout)
+		log.WithError(err).Warnf(
+			"Failed to get plugin config; falling back to caller-provided CSI snapshot timeout %v",
+			csiSnapshotTimeout)
+	} else {
+		log.Infof("Plugin config: %+v", config)
+		if config.CsiSnapshotTimeout > 0 {
+			csiSnapshotTimeout = time.Duration(config.CsiSnapshotTimeout) * time.Minute
+			log.Infof("Using configured CSI snapshot Timeout=%v", csiSnapshotTimeout)
+		}
 	}
 
 	// A single deadline context spans both phases. If Phase 1 consumes 3 minutes,

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-master.153
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0.49
+image = catalogicsoftware/velero:v1.14.0.50


### PR DESCRIPTION
CSI snapshot loss on backup finalize:
- Backup finalize was destroying the CSI cloud snapshot (COPY/plain jobs).
- Cause: a missing optional plugin ConfigMap made the finalize wait error.
- That error ran CleanupVolumeSnapshot, which cascade-deleted the snapshot.
- Handle Finalizing phases first, before WaitUntilVSCHandleIsReady.
- Finalize now uses GetVolumeSnapshotContentForVolumeSnapshot for the VSC.
- It deletes the VS via DeleteVolumeSnapshot, preserving the snapshot.
- Skip deletion if the bound VSC cannot be resolved during finalize.
- Make the plugin ConfigMap read non-fatal in WaitUntilVSCHandleIsReady.
- Fall back to backup.spec.csiSnapshotTimeout instead of erroring.
- Fix nil-deref panic on snapCont.Status.SnapshotHandle in VSC delete.
- Use Infof (not Info) for format strings in the CSI delete actions.

change-storage-class under parallel restores:
- Restore change-SC action listed ConfigMaps by a shared label.
- Parallel restores create many, so it errored or picked the wrong one.
- Fetch this restore's ConfigMap by name: cloudcasa-io-change-sc-<restore>.
- By-name Get avoids the ">1 ConfigMap" error and cross-restore mix-ups.
- It also ignores ConfigMaps orphaned by crashed restores.
- Missing ConfigMap or empty data stays a no-op, as before.
- Update tests and add a per-restore/parallelism test case.

Release:
- Bump velero image to v1.14.0.50 (Makefile, plugins.ini).

Fixes KUBEDR-8019

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
