### PR TITLE
KUBEDR-8058: Don't declare CSI snapshot ready when VSC has an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0-master.25
+VERSION ?= v1.14.0-master.26
 
 TAG_LATEST ?= false
 

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -53,6 +53,13 @@ import (
 const (
 	waitInternal                          = 2 * time.Second
 	volumeSnapshotContentProtectFinalizer = "velero.io/volume-snapshot-content-protect-finalizer"
+
+	// snapshotProgressDrainDelay is how long the deferred progress-reporter
+	// waits after writing the final snapshot state before deleting the progress
+	// ConfigMap. It gives the kubeagent time to observe and process the final
+	// update (including the "error" state on a failed/timed-out snapshot) before
+	// the ConfigMap is removed.
+	snapshotProgressDrainDelay = 500 * time.Millisecond
 )
 
 // WaitVolumeSnapshotReady waits a VS to become ready to use until the timeout reaches
@@ -954,6 +961,37 @@ func recreateVolumeSnapshotContent(
 	return nil
 }
 
+// vscErrorMessage returns the error message recorded on a
+// VolumeSnapshotContent's status, and whether an error is present at all. The
+// snapshot-controller records transient CSI driver errors here while it keeps
+// retrying in the background.
+func vscErrorMessage(vsc *snapshotv1api.VolumeSnapshotContent) (string, bool) {
+	if vsc == nil || vsc.Status == nil || vsc.Status.Error == nil {
+		return "", false
+	}
+	msg := ""
+	if vsc.Status.Error.Message != nil {
+		msg = *vsc.Status.Error.Message
+	}
+	return msg, true
+}
+
+// vscSnapshotReady reports whether a VolumeSnapshotContent should be treated as
+// a successfully-captured snapshot. It requires a populated SnapshotHandle AND
+// the absence of any error. A CSI driver can return a handle alongside a
+// transient error (e.g. a rate-limiter DeadlineExceeded); in that state the
+// handle may be stale and the VolumeSnapshot's ReadyToUse is still false, so
+// the VSC must NOT be considered ready.
+func vscSnapshotReady(vsc *snapshotv1api.VolumeSnapshotContent) bool {
+	if vsc == nil || vsc.Status == nil {
+		return false
+	}
+	if _, hasErr := vscErrorMessage(vsc); hasErr {
+		return false
+	}
+	return vsc.Status.SnapshotHandle != nil
+}
+
 // WaitUntilVSCHandleIsReady returns the VolumeSnapshotContent object associated
 // with the VolumeSnapshot. Instead of polling on a fixed interval, it uses
 // watchtools.UntilWithSync for both the VS-binding phase and the VSC
@@ -1004,7 +1042,7 @@ func WaitUntilVSCHandleIsReady(
 		if uErr != nil {
 			log.WithError(uErr).Error("Failed to update snapshot progress")
 		}
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(snapshotProgressDrainDelay)
 		catalogic.DeleteSnapshotProgressConfigMap(jobID, log)
 	}()
 
@@ -1096,6 +1134,14 @@ func WaitUntilVSCHandleIsReady(
 	); watchErr != nil {
 		log.WithError(watchErr).Errorf(
 			"Phase1 watch failed for VolumeSnapshot %s/%s", volSnap.Namespace, volSnap.Name)
+		// Record the failure and the impending cleanup before returning; the
+		// caller removes the incomplete snapshot on any error, and the deferred
+		// progress-reporter flushes this "error" state to the ConfigMap first
+		// so the snapshot never fails silently.
+		snapshotState = "error"
+		snapshotStateMessage = fmt.Sprintf(
+			"CSI snapshot did not bind before timeout for VolumeSnapshot %s/%s. The incomplete snapshot will be removed.",
+			volSnap.Namespace, volSnap.Name)
 		return nil, errors.Wrapf(watchErr,
 			"timed out or failed watching VolumeSnapshot %s/%s for VSC binding",
 			volSnap.Namespace, volSnap.Name)
@@ -1180,15 +1226,31 @@ func WaitUntilVSCHandleIsReady(
 				if !ok {
 					return false, nil
 				}
-				if updatedVSC.Status == nil || updatedVSC.Status.SnapshotHandle == nil {
+				// Do NOT treat the VSC as ready while it carries an error, even
+				// if a SnapshotHandle is already populated. A CSI driver can
+				// return a handle together with a transient error (e.g. a
+				// DeadlineExceeded from the client-side rate limiter). In that
+				// state the handle may be stale/invalid and the VolumeSnapshot's
+				// ReadyToUse is still false. Declaring success here consumes the
+				// whole csiSnapshotTimeout budget on a false positive. Keep
+				// watching until the error clears — or until the shared deadline
+				// fires, at which point the watchErr handler below turns the
+				// lingering error into a returned error, sending the caller down
+				// the CleanupVolumeSnapshot path that reclaims the incomplete
+				// snapshot.
+				if errMsg, hasErr := vscErrorMessage(updatedVSC); hasErr {
+					snapshotState = "pending"
+					snapshotStateMessage = fmt.Sprintf(
+						"VSC %s has error, awaiting CSI retry: %s", boundVSCName, errMsg)
+					log.Warnf("VSC %s reported an error; not treating as ready: %s",
+						boundVSCName, errMsg)
+					return false, nil
+				}
+				if !vscSnapshotReady(updatedVSC) {
 					snapshotState = "pending"
 					snapshotStateMessage = fmt.Sprintf(
 						"VSC %s lacks SnapshotHandle", boundVSCName)
 					log.Info(snapshotStateMessage)
-					if updatedVSC.Status != nil && updatedVSC.Status.Error != nil {
-						log.Infof("VSC %s has error: %v",
-							boundVSCName, *updatedVSC.Status.Error.Message)
-					}
 					return false, nil
 				}
 				// Capture the final, fully-populated VSC for the caller.
@@ -1200,10 +1262,24 @@ func WaitUntilVSCHandleIsReady(
 		},
 	); watchErr != nil {
 		log.WithError(watchErr).Errorf("Phase2 watch failed for VSC %s", boundVSCName)
-		if vsc.Status != nil && vsc.Status.Error != nil {
-			return nil, fmt.Errorf("CSI reconciliation timeout for VSC %s: %v",
-				boundVSCName, *vsc.Status.Error.Message)
+		// Record the failure and the impending cleanup in the progress
+		// ConfigMap before returning. The caller runs CleanupVolumeSnapshot on
+		// any error from this function, so the incomplete snapshot is about to
+		// be removed; the deferred progress-reporter above flushes this "error"
+		// state to the ConfigMap (and thus to the kubeagent) before the caller
+		// regains control — so the snapshot never fails silently.
+		if reason, hasErr := vscErrorMessage(vsc); hasErr {
+			snapshotState = "error"
+			snapshotStateMessage = fmt.Sprintf(
+				"CSI snapshot failed for VSC %s: %s. The incomplete snapshot will be removed.",
+				boundVSCName, reason)
+			return nil, fmt.Errorf("CSI reconciliation timeout for VSC %s: %s",
+				boundVSCName, reason)
 		}
+		snapshotState = "error"
+		snapshotStateMessage = fmt.Sprintf(
+			"CSI snapshot did not become ready before timeout for VSC %s. The incomplete snapshot will be removed.",
+			boundVSCName)
 		return nil, errors.Wrapf(watchErr,
 			"timed out or failed watching VSC %s for SnapshotHandle", boundVSCName)
 	}

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -1786,3 +1786,84 @@ func TestWaitUntilVSCHandleIsReady(t *testing.T) {
 		})
 	}
 }
+
+// TestVSCSnapshotReady covers the readiness decision used by
+// WaitUntilVSCHandleIsReady's Phase 2 watch. The critical case is a VSC that
+// carries BOTH a SnapshotHandle and an error — the state a rate-limited CSI
+// driver leaves behind — which must NOT be treated as ready.
+func TestVSCSnapshotReady(t *testing.T) {
+	handle := "snapshot-handle"
+	errMsg := "DeadlineExceeded: context deadline exceeded (client rate limiter)"
+
+	tests := []struct {
+		name       string
+		vsc        *snapshotv1api.VolumeSnapshotContent
+		wantReady  bool
+		wantErrMsg string
+		wantHasErr bool
+	}{
+		{
+			name:      "nil VSC is not ready",
+			vsc:       nil,
+			wantReady: false,
+		},
+		{
+			name:      "nil status is not ready",
+			vsc:       &snapshotv1api.VolumeSnapshotContent{},
+			wantReady: false,
+		},
+		{
+			name: "handle present without error is ready",
+			vsc: &snapshotv1api.VolumeSnapshotContent{
+				Status: &snapshotv1api.VolumeSnapshotContentStatus{
+					SnapshotHandle: &handle,
+				},
+			},
+			wantReady: true,
+		},
+		{
+			name: "no handle and no error is not ready",
+			vsc: &snapshotv1api.VolumeSnapshotContent{
+				Status: &snapshotv1api.VolumeSnapshotContentStatus{},
+			},
+			wantReady: false,
+		},
+		{
+			// A handle AND an error must not be treated as ready.
+			name: "handle present with error is NOT ready",
+			vsc: &snapshotv1api.VolumeSnapshotContent{
+				Status: &snapshotv1api.VolumeSnapshotContentStatus{
+					SnapshotHandle: &handle,
+					ReadyToUse:     boolptr.False(),
+					Error: &snapshotv1api.VolumeSnapshotError{
+						Message: &errMsg,
+					},
+				},
+			},
+			wantReady:  false,
+			wantErrMsg: errMsg,
+			wantHasErr: true,
+		},
+		{
+			name: "error with nil message still reports error and not ready",
+			vsc: &snapshotv1api.VolumeSnapshotContent{
+				Status: &snapshotv1api.VolumeSnapshotContentStatus{
+					SnapshotHandle: &handle,
+					Error:          &snapshotv1api.VolumeSnapshotError{},
+				},
+			},
+			wantReady:  false,
+			wantErrMsg: "",
+			wantHasErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantReady, vscSnapshotReady(tc.vsc))
+			gotMsg, gotHasErr := vscErrorMessage(tc.vsc)
+			assert.Equal(t, tc.wantHasErr, gotHasErr)
+			assert.Equal(t, tc.wantErrMsg, gotMsg)
+		})
+	}
+}

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-master.211
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0-master.25
+image = catalogicsoftware/velero:v1.14.0-master.26


### PR DESCRIPTION
- The watch now refuses to treat a VSC as ready while it carries an error and keeps watching until the error clears or the shared deadline fires.
- On timeout the caller receives an error and routes to CleanupVolumeSnapshot, which reclaims the incomplete snapshot (Path A) instead of hanging.
- The readiness decision is extracted into vscSnapshotReady / vscErrorMessage and unit-tested directly.
- Record CSI snapshot failure to progress ConfigMap on timeout
- In case of failure to snapshot a PVC, set snapshotState="error" with a specific reason.
- Give kubeagent more time to process final progress update
- Fix a latent nil dereference of vsc.Status.Error.Message on the Phase 2 timeout path by routing through vscErrorMessage.

Fixes KubeDR-8058

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
