### PR TITLE
Fix wrong day-of-month in catalogic snapshot-progress timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0-master.25
+VERSION ?= v1.14.0-master.26
 
 TAG_LATEST ?= false
 

--- a/internal/catalogic/types.go
+++ b/internal/catalogic/types.go
@@ -30,7 +30,11 @@ const (
 	// Prefix name of configmap used to to report progress of snapshot
 	SnapshotProgressUpdateConfigMapPrefix = "cloudcasa-io-snapshot-updater-"
 
-	TimeFormat = "2006-01-06 15:04:05 UTC: "
+	// TimeFormat must match the kubeagent's sibling layout exactly. Note the day
+	// token is "02": using "06" here renders the two-digit YEAR in the day
+	// position (e.g. day "26" throughout 2026), which previously masqueraded as
+	// clock skew in customer logs.
+	TimeFormat = "2006-01-02 15:04:05 UTC: "
 
 	// VeleroCsiPluginConfigMapPrefix is the name prefix of the configmap used to store configuration parameters
 	VeleroCsiPluginConfigMapPrefix = "cloudcasa-io-velero-csi-plugin-"

--- a/internal/catalogic/types_test.go
+++ b/internal/catalogic/types_test.go
@@ -1,0 +1,25 @@
+package catalogic
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTimeFormatRendersDayOfMonth guards against the "2006-01-06" typo class,
+// where the two-digit-year token "06" is mistakenly used in the day position.
+// A layout-shaped bug like this survives code review because it still looks
+// like a date; only a value-level assertion on a known instant catches it.
+//
+// The chosen instant deliberately has a day-of-month (05) that differs from
+// year%100 (26), month (03), hour (17), minute (41), and second (09) — so a
+// token transposition in any position produces an observably wrong string.
+func TestTimeFormatRendersDayOfMonth(t *testing.T) {
+	fixed := time.Date(2026, time.March, 5, 17, 41, 9, 0, time.UTC)
+
+	got := fixed.Format(TimeFormat)
+	want := "2026-03-05 17:41:09 UTC: "
+
+	if got != want {
+		t.Errorf("TimeFormat rendered %q, want %q (check for 06/02/01 token mix-ups)", got, want)
+	}
+}

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-master.211
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0-master.25
+image = catalogicsoftware/velero:v1.14.0-master.26


### PR DESCRIPTION
- Fix TimeFormat "2006-01-06" -> "2006-01-02" so day-of-month renders right.
- Go's "06" is the two-digit year token, so day showed year (e.g. "26" in 2026).
- Match kubeagent's sibling layout; trailing "UTC: " and spacing unchanged.
- Add regression test asserting a known instant formats to the exact string.
- Swept the fork: this was the only affected time layout.
- ConfigMap payload is write-only in the fork, so impact is cosmetic.
- Update Velero image tag to v1.14.0-master.26

Fixes KubeDR-8059

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
