### PR TITLE
Report VSC resolution failures on CSI snapshot progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0-master.26
+VERSION ?= v1.14.0-master.27
 
 TAG_LATEST ?= false
 

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -192,10 +192,14 @@ func (p *pvcBackupItemAction) createVolumeSnapshot(
 		p.crClient,
 	)
 	if err != nil {
-		return nil, nil, false, errors.Wrapf(
-			err, "failed to get VolumeSnapshotClass for StorageClass %s",
-			storageClass.Name,
-		)
+		// Surface the failure on the CSI snapshot-progress channel (relayed to
+		// KubeAgent) with the resolver's own actionable message, and return the
+		// error unwrapped so the backup-item error isn't padded with a redundant
+		// "failed to get VolumeSnapshotClass for StorageClass ..." prefix.
+		*snapshotState = "error"
+		*snapshotStateMessage = err.Error()
+		p.log.Error(err.Error())
+		return nil, nil, false, err
 	}
 	p.log.Infof(
 		"Using VolumeSnapshotClass %s for PVC %s/%s (StorageClass %s, driver %s)",

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -292,6 +292,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 	}
 
 	backupRequest.BackedUpItems = map[itemKey]struct{}{}
+	backupRequest.FailedItems = map[itemKey]error{}
 
 	podVolumeTimeout := kb.podVolumeTimeout
 	if val := backupRequest.Annotations[velerov1api.PodVolumeOperationTimeoutAnnotation]; val != "" {
@@ -713,6 +714,7 @@ func (kb *kubernetesBackupper) FinalizeBackup(
 	}
 
 	backupRequest.BackedUpItems = map[itemKey]struct{}{}
+	backupRequest.FailedItems = map[itemKey]error{}
 
 	// set up a temp dir for the itemCollector to use to temporarily
 	// store items as they're scraped from the API.

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -115,6 +115,19 @@ func (ib *itemBackupper) backupItem(logger logrus.FieldLogger, obj runtime.Unstr
 
 	selectedForBackup, files, err := ib.backupItemInternal(logger, obj, groupResource, preferredGVR, mustInclude, finalize)
 
+	// Remember failed items so that a later re-encounter (deduplicated via
+	// BackedUpItems) resurfaces the failure instead of passing for a success.
+	if err != nil {
+		if ib.backupRequest.FailedItems == nil {
+			ib.backupRequest.FailedItems = map[itemKey]error{}
+		}
+		ib.backupRequest.FailedItems[itemKey{
+			resource:  resourceKey(obj),
+			namespace: namespace,
+			name:      name,
+		}] = err
+	}
+
 	// Report result of the primary KubeVirt VM resource backup if it's a KubeVirt VM
 	if isKubeVirtVM {
 		kubevirtutil.KubeVirtVMOpResult(logger, groupResource, name, namespace, ib.backupRequest.Backup, selectedForBackup && err == nil, err, ib.kbClient)
@@ -242,6 +255,15 @@ func (ib *itemBackupper) backupItemInternal(logger logrus.FieldLogger, obj runti
 	}
 
 	if _, exists := ib.backupRequest.BackedUpItems[key]; exists {
+		// If the earlier attempt failed, resurface that failure so parents that
+		// reference this item (e.g. a KubeVirt VM whose PVC snapshot failed) do
+		// not treat it as successfully backed up.
+		if prevErr, failed := ib.backupRequest.FailedItems[key]; failed {
+			log.Info("Item was already processed and its backup failed; returning the previous failure.")
+			return false, itemFiles, errors.Wrapf(
+				prevErr, "item %s failed to back up earlier in this backup", key.name,
+			)
+		}
 		log.Info("Skipping item because it's already been backed up.")
 		// returning true since this item *is* in the backup, even though we're not backing it up here
 		return true, itemFiles, nil

--- a/pkg/backup/request.go
+++ b/pkg/backup/request.go
@@ -50,12 +50,19 @@ type Request struct {
 	VolumeSnapshots           []*volume.Snapshot
 	PodVolumeBackups          []*velerov1api.PodVolumeBackup
 	BackedUpItems             map[itemKey]struct{}
-	itemOperationsList        *[]*itemoperation.BackupOperation
-	ResPolicies               *resourcepolicies.Policies
-	SkippedPVTracker          *skipPVTracker
-	VolumesInformation        volume.BackupVolumesInformation
-	IncludeNamedResources     map[string]string
-	Context                   context.Context `json:"-"`
+	// FailedItems records, per item, the error from a failed backup attempt.
+	// BackedUpItems marks an item as processed before its backup runs (to break
+	// recursion cycles), so on re-encounter a previously FAILED item would
+	// otherwise be indistinguishable from a successful one and parents (e.g. a
+	// KubeVirt VM referencing a failed PVC) would report success. The dedup path
+	// consults this map to resurface the original failure instead.
+	FailedItems           map[itemKey]error
+	itemOperationsList    *[]*itemoperation.BackupOperation
+	ResPolicies           *resourcepolicies.Policies
+	SkippedPVTracker      *skipPVTracker
+	VolumesInformation    volume.BackupVolumesInformation
+	IncludeNamedResources map[string]string
+	Context               context.Context `json:"-"`
 }
 
 // BackupVolumesInformation contains the information needs by generating

--- a/plugins.ini
+++ b/plugins.ini
@@ -22,4 +22,4 @@ image = catalogicsoftware/amds-veleroplugin:3.1.0-master.211
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0-master.26
+image = catalogicsoftware/velero:v1.14.0-master.27


### PR DESCRIPTION
- Set snapshot state/message so the failure reaches KubeAgent.
- Return the resolver error unwrapped to drop a redundant prefix.
- Bump velero image tag to v1.14.0-master.27
- Track per-item backup failures in a new Request.FailedItems map
- Resurface the recorded error when dedup re-encounters a failed item
- A VM whose PVC snapshot failed now reports FAILED, not COMPLETED
- Keyed by group/version/kind, namespace, and name, same as dedup
- Scoped to a single backup run; reset alongside BackedUpItems

Fixes KubeDR-7799

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
