### PR TITLE
KUBEDR-8121: Skip backup object deletion for immutable objectstores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HUGO_IMAGE := hugo-builder
 local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
 ARCH ?= linux-amd64
 
-VERSION ?= v1.14.0-master.28
+VERSION ?= v1.14.0-master.29
 
 TAG_LATEST ?= false
 

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -101,6 +101,12 @@ const (
 	// ExcludeFromBackupLabel is the label to exclude k8s resource from backup,
 	// even if the resource contains a matching selector label.
 	ExcludeFromBackupLabel = "velero.io/exclude-from-backup"
+
+	// ObjectLockAnnotation is set on a BackupStorageLocation by the CloudCasa
+	// agent when the objectstore has an immutability (object lock) policy
+	// enabled. Deletion of objects in such a store is bound to fail, so
+	// controllers skip object storage deletions when this is "true".
+	ObjectLockAnnotation = "cloudcasa.io/object-lock"
 )
 
 type AsyncOperationIDPrefix string

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -390,9 +391,17 @@ func (r *backupDeletionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if backupStore != nil {
-		log.Info("Removing backup from backup storage")
-		if err := backupStore.DeleteBackup(backup.Name); err != nil {
-			errs = append(errs, err.Error())
+		if location.GetAnnotations()[velerov1api.ObjectLockAnnotation] == "true" {
+			log.Info("Immutable policy is enabled for this objectstore, skipping removal of backup data from backup storage")
+		} else {
+			log.Info("Removing backup from backup storage")
+			if err := backupStore.DeleteBackup(backup.Name); err != nil {
+				if isObjectLockError(err) {
+					log.WithError(err).Warn("Backup storage objects are protected by an immutability policy. Skipping delete and not retrying.")
+				} else {
+					errs = append(errs, err.Error())
+				}
+			}
 		}
 	}
 
@@ -702,4 +711,21 @@ func batchDeleteSnapshots(ctx context.Context, repoEnsurer *repository.Ensurer, 
 	}
 
 	return errs
+}
+
+// isObjectLockError reports whether err indicates that object storage
+// rejected a delete because of an immutability (object lock) policy.
+func isObjectLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+
+	// Azure: Blob is immutable
+	if strings.Contains(errStr, "BlobImmutableDueToPolicy") {
+		return true
+	}
+
+	// S3: Access denied due to Object Lock
+	return strings.Contains(errStr, "AccessDenied") && strings.Contains(errStr, "Object Lock")
 }

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -753,6 +753,13 @@ func (r *restoreReconciler) deleteExternalResources(restore *api.Restore) error 
 		return errors.Wrap(err, fmt.Sprintf("can't get backup info, backup: %s", restore.Spec.BackupName))
 	}
 
+	// The objectstore is immutable, so deleting the restore files is bound
+	// to fail. Skip the delete calls altogether.
+	if backupInfo.location.GetAnnotations()[api.ObjectLockAnnotation] == "true" {
+		r.logger.Info("Immutable policy is enabled for this objectstore, skipping deletion of restore files in object storage")
+		return nil
+	}
+
 	// delete restore files in object storage
 	pluginManager := r.newPluginManager(r.logger)
 	defer pluginManager.CleanupClients()
@@ -765,17 +772,8 @@ func (r *restoreReconciler) deleteExternalResources(restore *api.Restore) error 
 	// Actual call to delete restore files
 	err = backupStore.DeleteRestore(restore.Name)
 	if err != nil {
-		errStr := err.Error()
-
-		// Azure: Blob is immutable
-		if strings.Contains(errStr, "BlobImmutableDueToPolicy") {
-			r.logger.WithError(err).Warn("Azure Blob is immutable due to Object Lock. Skipping delete and not retrying.")
-			return nil
-		}
-
-		// S3: Access denied due to Object Lock
-		if strings.Contains(errStr, "AccessDenied") && strings.Contains(errStr, "Object Lock") {
-			r.logger.WithError(err).Warn("S3 object is protected by Object Lock. Skipping delete and not retrying.")
+		if isObjectLockError(err) {
+			r.logger.WithError(err).Warn("Restore files are protected by an immutability policy. Skipping delete and not retrying.")
 			return nil
 		}
 

--- a/plugins.ini
+++ b/plugins.ini
@@ -18,8 +18,8 @@ image = catalogicsoftware/kubevirt-velero-plugin:v0.7.1.3
 path = /plugins/kubevirt-velero-plugin
 
 [plugin:amds]
-image = catalogicsoftware/amds-veleroplugin:3.1.0-master.240
+image = catalogicsoftware/amds-veleroplugin:3.1.0-master.267
 path = /plugins/catalogicsoftware-velero-plugin
 
 [velero]
-image = catalogicsoftware/velero:v1.14.0-master.28
+image = catalogicsoftware/velero:v1.14.0-master.29


### PR DESCRIPTION
- Read cloudcasa.io/object-lock BSL annotation set by the kubeagent
- Deletion controller skips backupStore.DeleteBackup when annotation is true
- Rest of the DeleteBackupRequest workflow (snapshots, CRs) runs as before
- DBR no longer ends Processed with errors (PARTIAL) on immutable objectstores
- Add isObjectLockError helper to detect Azure/S3 object lock delete failures
- Tolerate object lock errors from DeleteBackup as a fallback when flag unset
- Restore finalizer checks the annotation before deleting restore files

Fixes KubeDR-8121

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
